### PR TITLE
Add possibility to perturb physics constants

### DIFF
--- a/components/homme/src/share/cxx/ColumnOps.hpp
+++ b/components/homme/src/share/cxx/ColumnOps.hpp
@@ -369,12 +369,13 @@ public:
     }
   }
 
-  template<int PackLength,bool Forward,bool Inclusive,int LENGTH,typename InputProvider,typename ST>
+  template<int PackLength,bool Forward,bool Inclusive,int LENGTH,
+           typename InputProvider,typename ST,typename... Props>
   KOKKOS_INLINE_FUNCTION
   static typename std::enable_if<PackLength==1>::type
   column_scan_impl (const KernelVariables& kv,
                     const InputProvider& input_provider,
-                    const ExecViewUnmanaged<ST [ColInfo<LENGTH>::NumPacks]>& sum,
+                    const ExecView<ST [ColInfo<LENGTH>::NumPacks],Props...>& sum,
                     const typename ekat::ScalarTraits<ST>::scalar_type s0 = 0.0)
   {
     using scalar_t = typename ekat::ScalarTraits<ST>::scalar_type;

--- a/components/homme/src/share/cxx/GllFvRemapImpl.cpp
+++ b/components/homme/src/share/cxx/GllFvRemapImpl.cpp
@@ -487,7 +487,7 @@ void GllFvRemapImpl
           eos.compute_pnh_and_exner(kv, vthdp_ij, Homme::subview(phi_i,ie,timeidx,i,j),
                                     wrk_ij, exner_ij);
         // theta_g
-        ops.get_temperature(kv, eos, use_moisture, dp3d_ij, exner_ij, vthdp_ij,
+        ops.get_temperature(kv, use_moisture, dp3d_ij, exner_ij, vthdp_ij,
                             Homme::subview(q_g,ie,0,i,j), wrk_ij, th_g_ij);
         const auto& rexner_ij = exner_ij;
         parallel_for(tvr, [&] (int k) { // could avoid this in H case but then would lose BFB

--- a/components/homme/src/share/cxx/GllFvRemapImpl.cpp
+++ b/components/homme/src/share/cxx/GllFvRemapImpl.cpp
@@ -406,7 +406,7 @@ void GllFvRemapImpl
                         dp.extent_int(2)/packn);
   }
   
-  EquationOfState eos; eos.init(theta_hydrostatic_mode, hvcoord);
+  EquationOfState<> eos; eos.init(theta_hydrostatic_mode, hvcoord);
   ElementOps ops; ops.init(hvcoord);
 
   const auto tu_ne = m_tu_ne;
@@ -607,7 +607,7 @@ run_fv_phys_to_dyn (const int timeidx, const CPhys2T& Ts, const CPhys3T& uvs,
   const auto hvcoord = m_hvcoord;
   const auto dp3d = m_state.m_dp3d;
   const bool theta_hydrostatic_mode = m_data.theta_hydrostatic_mode;
-  EquationOfState eos; eos.init(theta_hydrostatic_mode, hvcoord);
+  EquationOfState<> eos; eos.init(theta_hydrostatic_mode, hvcoord);
   ElementOps ops; ops.init(hvcoord);
   const auto tu_ne = m_tu_ne;
 

--- a/components/homme/src/share/cxx/PhysicalConstants.hpp
+++ b/components/homme/src/share/cxx/PhysicalConstants.hpp
@@ -28,6 +28,45 @@ namespace PhysicalConstants
   constexpr Real Tref          = 288;
 
   constexpr Real Tref_lapse_rate = 0.0065;
+}
+
+// This class simply provides the constants as device-friendly functions
+// Other classes (like EOS) can move to require a template arg, which tells
+// the compiler "where" to grab constants from. This allows us to swap in
+// the constants provider, so that we can for instance test sensitivities w.r.t
+// a physics constant. Of course, if a functor uses physics constants and we
+// want to test its sens calculation using the phys constants as param,
+// the functor impl must:
+//  - a) be templated on the constants provider
+//  - b) change PhysicalConstants::xyz to TemplateArg::xyz()
+
+struct PhysicalConstantsProvider {
+  // Thermodynamics constants
+  static KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real Rwater_vapor  () { return PhysicalConstants::Rwater_vapor;  }
+  static KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real Cpwater_vapor () { return PhysicalConstants::Cpwater_vapor; }
+  static KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real Rgas          () { return PhysicalConstants::Rgas;          }
+  static KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real cp            () { return PhysicalConstants::cp;            }
+  static KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real kappa         () { return PhysicalConstants::kappa;         }
+
+  static KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real Tref            () { return PhysicalConstants::Tref;            }
+  static KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real Tref_lapse_rate () { return PhysicalConstants::Tref_lapse_rate; }
+
+  // Earth constants
+  static KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real rearth0  () { return PhysicalConstants::rearth0;  }
+  static KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real rrearth0 () { return PhysicalConstants::rrearth0; }
+  static KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real g        () { return PhysicalConstants::g;        }
+  static KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real p0       () { return PhysicalConstants::p0;       }  // [mbar]
 };
 
 } // namespace Homme

--- a/components/homme/src/share/cxx/utilities/BfbUtils.hpp
+++ b/components/homme/src/share/cxx/utilities/BfbUtils.hpp
@@ -2,11 +2,29 @@
 #define HOMME_BFB_UTILS_HPP
 
 #include <Kokkos_Core.hpp>
+#ifdef HOMMEXX_ENABLE_FAD_TYPES
+#include <Sacado.hpp>
+#endif
 
 #include <ekat_pack.hpp>
 
+#include <type_traits>
+#include <utility>
+#include <cmath>
+
 namespace Homme
 {
+
+// Avoid sacado expressions, and figure out the final return type after evaluation
+template<typename BaseT, typename ExpT>
+struct PowRetT {
+#ifdef HOMMEXX_ENABLE_FAD_TYPES
+  using type = typename Sacado::Promote<BaseT,ExpT>::type;
+#else
+  using type = decltype(std::pow(std::declval<BaseT>(),std::declval<ExpT>()));
+#endif
+};
+
 // Set the least significant n bits of the fraction to 0. Use this for
 // BFB-testing between GPU and host. Zero the n least significant bits of y in
 //     y = pow(x, e),
@@ -108,26 +126,27 @@ ScalarType power_of_two (const ScalarType e) {
 
 // Note: force type to not be reference, so we can
 //       recycle inputs during calculations.
-template <typename ScalarType, typename ExpType>
+template <typename BaseT, typename ExpT,
+          typename = typename std::enable_if_t<!std::is_reference<BaseT>::value &&
+                                               !std::is_reference<ExpT>::value>::type>
 KOKKOS_INLINE_FUNCTION
-typename
-std::enable_if<!std::is_reference<ScalarType>::value &&
-               !std::is_reference<ExpType>::value, ScalarType>::type
-bfb_pow_impl (ScalarType val, ExpType e) {
+typename PowRetT<BaseT,ExpT>::type
+bfb_pow_impl (BaseT val, ExpT e)
+{
 #ifdef HOMMEXX_ENABLE_GPU
   // Note: this function is tailored (or taylored...eheh)
   // for -1<e<1.5 and 0.001 < b < 1e6
-  if (val<ScalarType(0)) {
+  if (val<BaseT(0)) {
     Kokkos::abort("Cannot take powers of negative numbers.\n");
   }
   if (e<-1.0 || e>1.5) {
     Kokkos::abort("bfb_pow x^a impl-ed with only -1.0<a<1.5 in mind.\n");
   }
-  if (val==ScalarType(0)) {
-    if (e==ExpType(0)) {
+  if (val==BaseT(0)) {
+    if (e==ExpT(0)) {
       Kokkos::abort("Cannot do 0^0, sorry man.\n");
     }
-    return ScalarType(0);
+    return 0;
   }
 
   if (e<0) {
@@ -135,8 +154,8 @@ bfb_pow_impl (ScalarType val, ExpType e) {
     val = 1/val;
   }
 
-  ScalarType factor = 1.0;
-  if (val>=ScalarType(1.5)) {
+  BaseT factor = 1.0;
+  if (val>=BaseT(1.5)) {
     int k=0;
     while (val>=16.0){
       k += 4;
@@ -164,8 +183,8 @@ bfb_pow_impl (ScalarType val, ExpType e) {
     factor = 1.0/int_pow(power_of_two(e),k);
   }
 
-  ScalarType x = val - ScalarType(1.0);
-  ScalarType y (1.0);
+  BaseT x = val - BaseT(1);
+  BaseT y (1.0);
 
   // (1+x)^a = 1+ax+a*(a-1)/2 x^2 + a*(a-1)*(a-2)/6 x^3 +...
   //         = 1+ax*(1+(a-1)/2 x *( 1+(a-2)/3 x * (1+...)))
@@ -182,20 +201,20 @@ bfb_pow_impl (ScalarType val, ExpType e) {
 #endif
 }
 
-template <typename PackType, typename ExpType>
+template <typename BaseT, typename ExpT, typename = std::enable_if_t<ekat::IsPack<BaseT>::value>>
 KOKKOS_INLINE_FUNCTION
-std::enable_if_t<PackType::packtag,PackType>
-bfb_pow (const PackType& a, const ExpType e)
+auto bfb_pow (const BaseT& a, const ExpT e)
 {
-  PackType b;
-  for (int s = 0; s < PackType::n; ++s) {
+  BaseT b;
+  for (int s = 0; s < BaseT::n; ++s) {
     b[s] = bfb_pow_impl(a[s], e);
   }
   return b;
 }
 
+template <typename BaseT, typename ExpT, typename = std::enable_if_t<!ekat::IsPack<BaseT>::value>>
 KOKKOS_INLINE_FUNCTION
-double bfb_pow (const double& a, const double e) {
+auto bfb_pow (const BaseT& a, const ExpT& e) {
   return bfb_pow_impl(a,e);
 }
 

--- a/components/homme/src/share/cxx/utilities/BfbUtils.hpp
+++ b/components/homme/src/share/cxx/utilities/BfbUtils.hpp
@@ -127,8 +127,8 @@ ScalarType power_of_two (const ScalarType e) {
 // Note: force type to not be reference, so we can
 //       recycle inputs during calculations.
 template <typename BaseT, typename ExpT,
-          typename = typename std::enable_if_t<!std::is_reference<BaseT>::value &&
-                                               !std::is_reference<ExpT>::value>::type>
+          typename = std::enable_if_t<!std::is_reference<BaseT>::value &&
+                                      !std::is_reference<ExpT>::value>>
 KOKKOS_INLINE_FUNCTION
 typename PowRetT<BaseT,ExpT>::type
 bfb_pow_impl (BaseT val, ExpT e)

--- a/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
@@ -99,7 +99,7 @@ struct CaarFunctorImplST {
   ElementsStateST<ST>         m_state;
   ElementsDerivedStateST<ST>  m_derived;
   ElementsGeometry            m_geometry;
-  EquationOfState             m_eos;
+  EquationOfState<>           m_eos;
   Buffers                     m_buffers;
   deriv_type                  m_deriv;
 

--- a/components/homme/src/theta-l_kokkos/cxx/Diagnostics.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/Diagnostics.cpp
@@ -123,10 +123,16 @@ void Diagnostics::sync_diagnostics_to_host () {
       int beg[4] = {};
       int end[4] = {m_num_elems, NUM_DIAG_TIMES,NP,NP};
       Kokkos::MDRangePolicy<ExecSpace,Kokkos::Rank<4>> p(beg,end);
+      auto IE = d_IEner;
+      auto KE = d_KEner;
+      auto PE = d_PEner;
+      auto IE_r = d_IEner_r;
+      auto KE_r = d_KEner_r;
+      auto PE_r = d_PEner_r;
       auto copy_energy = KOKKOS_LAMBDA(int ie, int k, int ip, int jp) {
-        d_IEner_r(ie,k,ip,jp) = ADValue(d_IEner(ie,k,ip,jp));
-        d_KEner_r(ie,k,ip,jp) = ADValue(d_KEner(ie,k,ip,jp));
-        d_PEner_r(ie,k,ip,jp) = ADValue(d_PEner(ie,k,ip,jp));
+        IE_r(ie,k,ip,jp) = ADValue(IE(ie,k,ip,jp));
+        KE_r(ie,k,ip,jp) = ADValue(KE(ie,k,ip,jp));
+        PE_r(ie,k,ip,jp) = ADValue(PE(ie,k,ip,jp));
       };
       Kokkos::parallel_for(p,copy_energy);
     }
@@ -134,12 +140,18 @@ void Diagnostics::sync_diagnostics_to_host () {
       int beg[4] = {};
       int end[4] = {m_num_elems, QSIZE_D,NP,NP};
       Kokkos::MDRangePolicy<ExecSpace,Kokkos::Rank<4>> p(beg,end);
+      auto Qvar_r  = d_Qvar_r;
+      auto Qmass_r = d_Qmass_r;
+      auto Q1mass_r = d_Q1mass_r;
+      auto Qvar  = d_Qvar;
+      auto Qmass = d_Qmass;
+      auto Q1mass = d_Q1mass;
       auto copy_tracers = KOKKOS_LAMBDA(int ie, int iq, int ip, int jp) {
         for (int k=0; k<NUM_DIAG_TIMES; ++k) {
-          d_Qvar_r(ie,k,iq,ip,jp) = ADValue(d_Qvar(ie,k,iq,ip,jp));
-          d_Qmass_r(ie,k,iq,ip,jp) = ADValue(d_Qmass(ie,k,iq,ip,jp));
+          Qvar_r(ie,k,iq,ip,jp) = ADValue(Qvar(ie,k,iq,ip,jp));
+          Qmass_r(ie,k,iq,ip,jp) = ADValue(Qmass(ie,k,iq,ip,jp));
         }
-        d_Q1mass_r(ie,iq,ip,jp) = ADValue(d_Q1mass(ie,iq,ip,jp));
+        Q1mass_r(ie,iq,ip,jp) = ADValue(Q1mass(ie,iq,ip,jp));
       };
       Kokkos::parallel_for(p,copy_tracers);
     }

--- a/components/homme/src/theta-l_kokkos/cxx/Diagnostics.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/Diagnostics.hpp
@@ -281,7 +281,7 @@ public:
   ExecViewManaged<ScalarValue*                [QSIZE_D][NP][NP]> d_Q1mass;
 
   HybridVCoord      m_hvcoord;
-  EquationOfState   m_eos;
+  EquationOfState<> m_eos;
   ElementOps        m_elem_ops;
   ElementsState     m_state;
   ElementsGeometry  m_geometry;

--- a/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
@@ -188,9 +188,9 @@ struct DirkFunctorImplST {
         const auto phi_i_c = Homme::subview(phi_i,igp,jgp);
 
         elem_ops.compute_hydrostatic_p(kv, Homme::subview(e_dp3d,ie,np1,igp,jgp), p_i_c, p_c);
-        EquationOfState::compute_phi_i(kv, e_phis(ie,igp,jgp),
-                                       Homme::subview(e_vtheta_dp,ie,np1,igp,jgp),
-                                       p_c, phi_i_c);
+        EquationOfState<>::compute_phi_i(kv, e_phis(ie,igp,jgp),
+                                         Homme::subview(e_vtheta_dp,ie,np1,igp,jgp),
+                                         p_c, phi_i_c);
 
         // Copy phi_i for use in run_newton. Don't need nlevp, since that's
         // always phis.
@@ -577,7 +577,7 @@ struct DirkFunctorImplST {
       const auto g = [&] (const int i) {
         for (int s = 0; s < ns; ++s)
           if (vtheta_dp(k,i)[s] < 0 || dphi(k,i)[s] > 0) ok = false;
-        EquationOfState::compute_pnh_and_exner(
+        EquationOfState<>::compute_pnh_and_exner(
           vtheta_dp(k,i), dphi(k,i), pnh(k,i), exner(k,i));
       };
       parallel_for(pv, g);
@@ -633,7 +633,7 @@ struct DirkFunctorImplST {
     kv.team_barrier();
     // Do most of the flops.
     loop_ki(kv, nlev, nvec, [&] (int k, int i) {
-      wrk(k,i) = EquationOfState::compute_dphi(vtheta_dp(k,i), wrk(k,i)); // dphi
+      wrk(k,i) = EquationOfState<>::compute_dphi(vtheta_dp(k,i), wrk(k,i)); // dphi
     });
     kv.team_barrier();
     // Scan to compute phi_i.

--- a/components/homme/src/theta-l_kokkos/cxx/ElementOps.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementOps.hpp
@@ -5,7 +5,6 @@
 #include "KernelVariables.hpp"
 #include "HybridVCoord.hpp"
 #include "ColumnOps.hpp"
-#include "EquationOfState.hpp"
 #include "PhysicalConstants.hpp"
 
 #include "utilities/BfbUtils.hpp"
@@ -57,7 +56,6 @@ public:
   template<typename InputProvider, typename PT, typename... Props>
   KOKKOS_FUNCTION
   void get_temperature (const KernelVariables& kv,
-                        const EquationOfState& eos,
                         const bool use_moisture,
                         const InputProvider& dp,
                         const InputProvider& exner,

--- a/components/homme/src/theta-l_kokkos/cxx/EquationOfState.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/EquationOfState.hpp
@@ -12,6 +12,7 @@
 
 namespace Homme {
 
+template<typename Constants = PhysicalConstantsProvider>
 class EquationOfState {
 public:
 
@@ -33,11 +34,11 @@ public:
   template<typename ST>
   KOKKOS_INLINE_FUNCTION
   static void pressure_to_exner (ST& pe) {
-    pe /= PhysicalConstants::p0;
+    pe /= Constants::p0();
 #ifdef HOMMEXX_BFB_TESTING
-    pe = bfb_pow(pe,PhysicalConstants::kappa);
+    pe = bfb_pow(pe,Constants::kappa());
 #else
-    pe = pow(pe,PhysicalConstants::kappa);
+    pe = pow(pe,Constants::kappa());
 #endif
   }
 
@@ -45,11 +46,11 @@ public:
   template<typename ST>
   KOKKOS_INLINE_FUNCTION
   static void pressure_to_recip_exner (ST& pe) {
-    pe = PhysicalConstants::p0 / pe;
+    pe = Constants::p0() / pe;
 #ifdef HOMMEXX_BFB_TESTING
-    pe = bfb_pow(pe,PhysicalConstants::kappa);
+    pe = bfb_pow(pe,Constants::kappa());
 #else
-    pe = pow(pe,PhysicalConstants::kappa);
+    pe = pow(pe,Constants::kappa());
 #endif
   }
 
@@ -104,14 +105,14 @@ public:
   KOKKOS_INLINE_FUNCTION
   static void compute_pnh_and_exner (const ST& vtheta_dp, const ST& dphi,
                                      ST& pnh, ST& exner) {
-    exner = (-PhysicalConstants::Rgas)*vtheta_dp / dphi;
-    pnh = exner/PhysicalConstants::p0;
+    exner = (-Constants::Rgas())*vtheta_dp / dphi;
+    pnh = exner/Constants::p0();
 #ifndef HOMMEXX_BFB_TESTING
-    pnh = pow(pnh,1.0/(1.0-PhysicalConstants::kappa));
+    pnh = pow(pnh,1.0/(1.0-Constants::kappa()));
 #else
-    pnh = bfb_pow(pnh,1.0/(1.0-PhysicalConstants::kappa));
+    pnh = bfb_pow(pnh,1.0/(1.0-Constants::kappa()));
 #endif
-    pnh *= PhysicalConstants::p0;
+    pnh *= Constants::p0();
     exner = pnh/exner;    
   }
 
@@ -203,9 +204,9 @@ public:
   template<typename ST>
   KOKKOS_INLINE_FUNCTION static
   ST compute_dphi (const ST& vtheta_dp, const ST& p) {
-    constexpr Real p0    = PhysicalConstants::p0;
-    constexpr Real kappa = PhysicalConstants::kappa;
-    constexpr Real Rgas  = PhysicalConstants::Rgas;
+    const auto p0    = Constants::p0();
+    const auto kappa = Constants::kappa();
+    const auto Rgas  = Constants::Rgas();
 #ifdef HOMMEXX_BFB_TESTING
     return (Rgas*vtheta_dp * bfb_pow(p/p0,kappa-1)) / p0;
 #else
@@ -249,8 +250,8 @@ public:
     phi_i(LAST_INT_PACK)[LAST_INT_PACK_END] = phis;
 
     // Use ColumnOps to do the scan sum
+    const auto Rgas  = Constants::Rgas();
     auto integrand_provider = [&](const int ilev) {
-      constexpr Real Rgas  = PhysicalConstants::Rgas;
       return Rgas*vtheta_dp(ilev)*exner(ilev)/p(ilev);
     };
 

--- a/components/homme/src/theta-l_kokkos/cxx/ForcingFunctor.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ForcingFunctor.hpp
@@ -556,7 +556,7 @@ private:
 
   HybridVCoord      m_hvcoord;
   ElementOps        m_elem_ops;
-  EquationOfState   m_eos;
+  EquationOfState<> m_eos;
 
   const int m_num_state_elems;
   const int m_num_tracer_elems;

--- a/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/HyperviscosityFunctorImpl.hpp
@@ -404,7 +404,7 @@ protected:
   ElementsGeometry            m_geometry;
   SphereOperatorsST<ST>       m_sphere_ops;
   ElementOps                  m_elem_ops;
-  EquationOfState             m_eos;
+  EquationOfState<>           m_eos;
   Buffers                     m_buffers;
   HybridVCoord                m_hvcoord;
 

--- a/components/homme/src/theta-l_kokkos/cxx/RemapStateProvider.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/RemapStateProvider.hpp
@@ -25,7 +25,7 @@ namespace Remap {
 
 struct RemapStateProvider {
 
-  EquationOfState   m_eos;
+  EquationOfState<> m_eos;
   ElementOps        m_elem_ops;
   ElementsState     m_state;
   ElementsGeometry  m_geometry;

--- a/components/homme/test_execs/thetal_kokkos_ut/CMakeLists.txt
+++ b/components/homme/test_execs/thetal_kokkos_ut/CMakeLists.txt
@@ -367,12 +367,20 @@ if (NOT HOMMEXX_ENABLE_FWD_SENS)
   cxx_unit_test_add_test(gllfvremap_planar_ut gllfvremap_ut ${NUM_CPUS} "hommexx -planar")
 endif()
 
-include (EkatCreateUnitTest)
-
 if (HOMMEXX_ENABLE_FAD_TYPES)
-  # ### Caar sacado derivatives tests
-  EkatCreateUnitTest ("caar_sacado_ut"
+  include (EkatCreateUnitTest)
+
+  # Caar sacado derivatives tests
+  EkatCreateUnitTest (caar_sacado_ut
     "caar_sacado_ut.cpp;${SHARE_UT_DIR}/geometry_interface.F90;thetal_test_interface.F90"
+    COMPILER_CXX_DEFS HOMMEXX_SPHERE_OP_ST_FACTORS
+    LIBS thetal_kokkos_ut_lib
+    LABELS AMDIS
+  )
+
+  # Eqn of state sacado derivatives tests
+  EkatCreateUnitTest (eos_sacado_ut
+    eos_sacado_ut.cpp
     COMPILER_CXX_DEFS HOMMEXX_SPHERE_OP_ST_FACTORS
     LIBS thetal_kokkos_ut_lib
     LABELS AMDIS

--- a/components/homme/test_execs/thetal_kokkos_ut/compose_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/compose_ut.cpp
@@ -274,8 +274,8 @@ private:
       ts.flags.erase("nonearest");
     }
 
-    auto print_key = [](const auto it) {
-      return it->first;
+    auto print_key = [](const auto& it) {
+      return it.first;
     };
     EKAT_REQUIRE_MSG(ts.flags.size()==0,
         "Error! Unrecognized flags: " + ekat::join(ts.flags,print_key,",") + "\n");

--- a/components/homme/test_execs/thetal_kokkos_ut/eos_sacado_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/eos_sacado_ut.cpp
@@ -7,6 +7,12 @@
 
 #include <ekat_string_utils.hpp>
 
+#include <algorithm>   // std::min_element
+#include <cmath>       // std::abs
+#include <iostream>    // std::cout
+#include <random>      // std::random_device, std::mt19937_64, std::uniform_real_distribution
+#include <vector>      // std::vector
+
 namespace Homme {
 
 namespace PC = PhysicalConstants;
@@ -69,8 +75,10 @@ bool check_fad_vs_fd (Func&& run,
   // 100x smaller than the coarsest-h error. With h_vals spanning 1e-2 to 1e-8,
   // the truncation error drops by ~1e4 before round-off dominates, so the
   // minimum is well below fd_errors[0]/100.
+  // Special case: if the coarsest-h FD error is already zero (FAD and FD agree
+  // exactly at h[0]), there is nothing to converge from - treat as success.
   const Real min_err = *std::min_element(fd_errors.begin(),fd_errors.end());
-  return (min_err < fd_errors[0] / 1e2);
+  return (fd_errors[0] == 0.0) || (min_err < fd_errors[0] / 1e2);
 }
 
 TEST_CASE("eos_dp_check") {
@@ -90,12 +98,13 @@ TEST_CASE("eos_dp_check") {
 
   using FadT = SFadN<Real,1>;
 
-  // Seed the FAD perturbation: perturb has value 0, derivative 1
-  PerturbedConstants<FadT> prov_fad;
+  // Seed the FAD perturbation: perturb has value 0, derivative 1.
+  // The constructor call initialises the static perturb member to ST(0).
+  (void)PerturbedConstants<FadT>{};
   PerturbedConstants<FadT>::perturb.fastAccessDx(0) = 1.0;
 
-  // Real provider (perturb starts at 0 from constructor)
-  PerturbedConstants<Real> prov_real;
+  // Real provider: constructor initialises static perturb to 0.
+  (void)PerturbedConstants<Real>{};
 
   // Step sizes for finite differences: from coarse to fine to probe convergence
   const std::vector<Real> h_vals = {1e-2, 1e-4, 1e-6, 1e-8};

--- a/components/homme/test_execs/thetal_kokkos_ut/eos_sacado_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/eos_sacado_ut.cpp
@@ -1,0 +1,79 @@
+#include <catch2/catch.hpp>
+
+#include "PhysicalConstants.hpp"
+#include "EquationOfState.hpp"
+
+#include "utilities/TestUtils.hpp"
+
+#include <ekat_string_utils.hpp>
+
+namespace Homme {
+
+namespace PC = PhysicalConstants;
+
+template<typename ST>
+struct PerturbedConstants {
+
+  PerturbedConstants() { perturb = ST(0); }
+
+  static ST perturb;
+
+  // Only decl the ones used in EOS
+  static KOKKOS_FORCEINLINE_FUNCTION constexpr ST   Rgas  () { return (1+perturb)*PC::Rgas; }
+  static KOKKOS_FORCEINLINE_FUNCTION constexpr Real cp    () { return PC::cp;           }
+  static KOKKOS_FORCEINLINE_FUNCTION constexpr ST   kappa () { return Rgas() / cp();    }
+  static KOKKOS_FORCEINLINE_FUNCTION constexpr Real p0    () { return PC::p0;           }  // [mbar]
+};
+
+template<typename ST>
+ST PerturbedConstants<ST>::perturb; // Must instantiate static member vars
+
+template<typename Provider>
+using EOS = EquationOfState<Provider>;
+
+TEST_CASE("eos_dp_check") {
+
+  // The random numbers generator
+  std::random_device rd;
+  using rngAlg = std::mt19937_64;
+  const unsigned int catchRngSeed = Catch::rngSeed();
+  const unsigned int seed = catchRngSeed==0 ? rd() : catchRngSeed;
+  std::cout << "seed: " << seed << (catchRngSeed==0 ? " (catch rng seed was 0)\n" : "\n");
+  rngAlg engine(seed);
+  using RPDF = std::uniform_real_distribution<Real>;
+
+  // Create and init hvcoord
+  HybridVCoord hvcoord;
+  hvcoord.random_init(seed);
+
+  using FadT = SFadN<Real,1>;
+
+  PerturbedConstants<Real> provider_real;
+  PerturbedConstants<FadT> provider_sfad;
+  provider_sfad.perturb.fastAccessDx(0) = 1;
+  for (bool hydrostatic : {true, false}) {
+    // Create the EOS objects
+    EOS<PerturbedConstants<Real>> eos_real;
+    EOS<PerturbedConstants<FadT>> eos_sfad;
+
+    eos_real.init(hydrostatic,hvcoord);
+    eos_sfad.init(hydrostatic,hvcoord);
+
+    SECTION ("pressure_to_exner") {
+
+      RPDF pdf(10,1000);
+
+      Real p_real0 = pdf(engine);
+      FadT p_sfad  = p_real0;
+
+      // Run eos_sfad::pressure_to_exner
+      // Run eos_real::pressure_to_exner for provider.perturb=0
+      // Run eos_real::pressure_to_exner for provider.perturb=1,0.1,0.01,0.001,...
+      // Compute finite-diff deriv dexner/dperturb, compare with Fad deriv
+    }
+    // Add similar sections for other EquationOfState methods
+  }
+
+}
+
+} // namespace Homme

--- a/components/homme/test_execs/thetal_kokkos_ut/eos_sacado_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/eos_sacado_ut.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>   // std::min_element
 #include <cmath>       // std::abs
 #include <iostream>    // std::cout
+#include <limits>      // std::numeric_limits
 #include <random>      // std::random_device, std::mt19937_64, std::uniform_real_distribution
 #include <vector>      // std::vector
 
@@ -75,10 +76,11 @@ bool check_fad_vs_fd (Func&& run,
   // 100x smaller than the coarsest-h error. With h_vals spanning 1e-2 to 1e-8,
   // the truncation error drops by ~1e4 before round-off dominates, so the
   // minimum is well below fd_errors[0]/100.
-  // Special case: if the coarsest-h FD error is already zero (FAD and FD agree
-  // exactly at h[0]), there is nothing to converge from - treat as success.
+  // Special case: if the coarsest-h FD error is already at machine epsilon
+  // (FAD and FD agree to floating-point precision at h[0]), there is nothing
+  // to converge from - treat as success.
   const Real min_err = *std::min_element(fd_errors.begin(),fd_errors.end());
-  return (fd_errors[0] == 0.0) || (min_err < fd_errors[0] / 1e2);
+  return (fd_errors[0] < std::numeric_limits<Real>::epsilon()) || (min_err < fd_errors[0] / 1e2);
 }
 
 TEST_CASE("eos_dp_check") {

--- a/components/homme/test_execs/thetal_kokkos_ut/eos_sacado_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/eos_sacado_ut.cpp
@@ -11,6 +11,10 @@ namespace Homme {
 
 namespace PC = PhysicalConstants;
 
+// A constants provider that perturbs Rgas by a factor (1+perturb).
+// kappa = Rgas/cp is also perturbed as a result.
+// p0 and cp are left unchanged.
+// The perturbation is a static member so it works inside KOKKOS_INLINE_FUNCTION.
 template<typename ST>
 struct PerturbedConstants {
 
@@ -19,10 +23,10 @@ struct PerturbedConstants {
   static ST perturb;
 
   // Only decl the ones used in EOS
-  static KOKKOS_FORCEINLINE_FUNCTION constexpr ST   Rgas  () { return (1+perturb)*PC::Rgas; }
-  static KOKKOS_FORCEINLINE_FUNCTION constexpr Real cp    () { return PC::cp;           }
-  static KOKKOS_FORCEINLINE_FUNCTION constexpr ST   kappa () { return Rgas() / cp();    }
-  static KOKKOS_FORCEINLINE_FUNCTION constexpr Real p0    () { return PC::p0;           }  // [mbar]
+  static KOKKOS_FORCEINLINE_FUNCTION ST   Rgas  () { return (1+perturb)*PC::Rgas; }
+  static KOKKOS_FORCEINLINE_FUNCTION Real cp    () { return PC::cp;           }
+  static KOKKOS_FORCEINLINE_FUNCTION ST   kappa () { return Rgas() / cp();    }
+  static KOKKOS_FORCEINLINE_FUNCTION Real p0    () { return PC::p0;           }  // [mbar]
 };
 
 template<typename ST>
@@ -30,6 +34,40 @@ ST PerturbedConstants<ST>::perturb; // Must instantiate static member vars
 
 template<typename Provider>
 using EOS = EquationOfState<Provider>;
+
+// Helper: compute FAD derivative and value for a scalar EOS function,
+// and compare against finite differences as the perturbation h is refined.
+// Returns true if the minimum finite-diff error is small enough.
+template<typename Func>
+bool check_fad_vs_fd (Func&& run,
+                      Real fad_val, Real fad_deriv,
+                      const std::vector<Real>& h_vals,
+                      const char* name)
+{
+  // baseline: run with perturb=0
+  PerturbedConstants<Real>::perturb = 0.0;
+  const Real f0 = run(0.0);
+
+  // Check FAD value matches the baseline
+  if (std::abs(fad_val - f0) > 1e-14 * std::abs(f0) + 1e-14) {
+    std::cout << name << ": FAD val=" << fad_val << " != baseline=" << f0 << "\n";
+    return false;
+  }
+
+  std::vector<Real> fd_errors;
+  for (Real h : h_vals) {
+    const Real fh = run(h);
+    const Real fd = (fh - f0) / h;
+    fd_errors.push_back(std::abs(fd - fad_deriv));
+  }
+
+  std::cout << name << ": FAD deriv = " << fad_deriv << "\n";
+  std::cout << "  h   = [" << ekat::join(h_vals,",") << "]\n";
+  std::cout << "  |FD-FAD| = [" << ekat::join(fd_errors,",") << "]\n";
+
+  const Real min_err = *std::min_element(fd_errors.begin(),fd_errors.end());
+  return (min_err < fd_errors[0] / 1e2);
+}
 
 TEST_CASE("eos_dp_check") {
 
@@ -42,38 +80,137 @@ TEST_CASE("eos_dp_check") {
   rngAlg engine(seed);
   using RPDF = std::uniform_real_distribution<Real>;
 
-  // Create and init hvcoord
+  // Create and init hvcoord (needed for EOS init, even though static scalar methods don't use it)
   HybridVCoord hvcoord;
   hvcoord.random_init(seed);
 
   using FadT = SFadN<Real,1>;
 
-  PerturbedConstants<Real> provider_real;
-  PerturbedConstants<FadT> provider_sfad;
-  provider_sfad.perturb.fastAccessDx(0) = 1;
-  for (bool hydrostatic : {true, false}) {
-    // Create the EOS objects
-    EOS<PerturbedConstants<Real>> eos_real;
-    EOS<PerturbedConstants<FadT>> eos_sfad;
+  // Seed the FAD perturbation: perturb has value 0, derivative 1
+  PerturbedConstants<FadT> prov_fad;
+  PerturbedConstants<FadT>::perturb.fastAccessDx(0) = 1.0;
 
-    eos_real.init(hydrostatic,hvcoord);
-    eos_sfad.init(hydrostatic,hvcoord);
+  // Real provider (perturb starts at 0 from constructor)
+  PerturbedConstants<Real> prov_real;
 
-    SECTION ("pressure_to_exner") {
+  // Step sizes for finite differences: from coarse to fine to probe convergence
+  const std::vector<Real> h_vals = {1e-2, 1e-4, 1e-6, 1e-8};
 
-      RPDF pdf(10,1000);
+  SECTION ("pressure_to_exner") {
+    RPDF pdf(10, 1000);
+    const Real p0 = pdf(engine);
 
-      Real p_real0 = pdf(engine);
-      FadT p_sfad  = p_real0;
+    // Run EOS with Fad type to get FAD derivative
+    FadT p_sfad = p0;
+    EOS<PerturbedConstants<FadT>>::pressure_to_exner(p_sfad);
+    const Real fad_val   = p_sfad.val();
+    const Real fad_deriv = p_sfad.fastAccessDx(0);
 
-      // Run eos_sfad::pressure_to_exner
-      // Run eos_real::pressure_to_exner for provider.perturb=0
-      // Run eos_real::pressure_to_exner for provider.perturb=1,0.1,0.01,0.001,...
-      // Compute finite-diff deriv dexner/dperturb, compare with Fad deriv
-    }
-    // Add similar sections for other EquationOfState methods
+    auto run = [&](Real h) {
+      PerturbedConstants<Real>::perturb = h;
+      Real p = p0;
+      EOS<PerturbedConstants<Real>>::pressure_to_exner(p);
+      PerturbedConstants<Real>::perturb = 0.0;
+      return p;
+    };
+
+    REQUIRE(check_fad_vs_fd(run, fad_val, fad_deriv, h_vals, "pressure_to_exner"));
   }
 
-}
+  SECTION ("pressure_to_recip_exner") {
+    RPDF pdf(10, 1000);
+    const Real p0 = pdf(engine);
+
+    FadT p_sfad = p0;
+    EOS<PerturbedConstants<FadT>>::pressure_to_recip_exner(p_sfad);
+    const Real fad_val   = p_sfad.val();
+    const Real fad_deriv = p_sfad.fastAccessDx(0);
+
+    auto run = [&](Real h) {
+      PerturbedConstants<Real>::perturb = h;
+      Real p = p0;
+      EOS<PerturbedConstants<Real>>::pressure_to_recip_exner(p);
+      PerturbedConstants<Real>::perturb = 0.0;
+      return p;
+    };
+
+    REQUIRE(check_fad_vs_fd(run, fad_val, fad_deriv, h_vals, "pressure_to_recip_exner"));
+  }
+
+  SECTION ("compute_dphi") {
+    RPDF pdf(1, 100);
+    const Real vtheta_dp = pdf(engine);
+    const Real p_in      = pdf(engine);
+
+    // FAD version: inputs are plain (no seed), only constants carry the Fad derivative
+    const FadT vtheta_dp_fad = vtheta_dp;
+    const FadT p_fad         = p_in;
+    const FadT dphi_sfad     = EOS<PerturbedConstants<FadT>>::compute_dphi(vtheta_dp_fad, p_fad);
+    const Real fad_val   = dphi_sfad.val();
+    const Real fad_deriv = dphi_sfad.fastAccessDx(0);
+
+    auto run = [&](Real h) {
+      PerturbedConstants<Real>::perturb = h;
+      Real dphi = EOS<PerturbedConstants<Real>>::compute_dphi(vtheta_dp, p_in);
+      PerturbedConstants<Real>::perturb = 0.0;
+      return dphi;
+    };
+
+    REQUIRE(check_fad_vs_fd(run, fad_val, fad_deriv, h_vals, "compute_dphi"));
+  }
+
+  SECTION ("compute_pnh_and_exner") {
+    // For compute_pnh_and_exner, we need:
+    //   exner_tmp = (-Rgas)*vtheta_dp / dphi  to be > 0 so that pow is valid
+    // This requires vtheta_dp > 0 and dphi < 0 (delta(phi_i) is negative since phi increases upward)
+    RPDF pdf_pos(1, 100);
+    RPDF pdf_neg(-100, -1);
+    const Real vtheta_dp = pdf_pos(engine);
+    const Real dphi      = pdf_neg(engine);
+
+    // FAD version
+    const FadT vtheta_dp_fad = vtheta_dp;
+    const FadT dphi_fad      = dphi;
+    FadT pnh_fad, exner_fad;
+    EOS<PerturbedConstants<FadT>>::compute_pnh_and_exner(vtheta_dp_fad, dphi_fad, pnh_fad, exner_fad);
+    const Real fad_pnh_val    = pnh_fad.val();
+    const Real fad_exner_val  = exner_fad.val();
+    const Real fad_dpnh_deps  = pnh_fad.fastAccessDx(0);
+    const Real fad_dexner_deps = exner_fad.fastAccessDx(0);
+
+    // Baseline Real values
+    PerturbedConstants<Real>::perturb = 0.0;
+    Real pnh_0 = 0, exner_0 = 0;
+    EOS<PerturbedConstants<Real>>::compute_pnh_and_exner(vtheta_dp, dphi, pnh_0, exner_0);
+
+    REQUIRE(std::abs(fad_pnh_val - pnh_0)   < 1e-14 * std::abs(pnh_0)   + 1e-14);
+    REQUIRE(std::abs(fad_exner_val - exner_0) < 1e-14 * std::abs(exner_0) + 1e-14);
+
+    // Finite difference for pnh
+    {
+      auto run_pnh = [&](Real h) {
+        PerturbedConstants<Real>::perturb = h;
+        Real pnh_h = 0, exner_h = 0;
+        EOS<PerturbedConstants<Real>>::compute_pnh_and_exner(vtheta_dp, dphi, pnh_h, exner_h);
+        PerturbedConstants<Real>::perturb = 0.0;
+        return pnh_h;
+      };
+      REQUIRE(check_fad_vs_fd(run_pnh, fad_pnh_val, fad_dpnh_deps, h_vals, "compute_pnh_and_exner::pnh"));
+    }
+
+    // Finite difference for exner
+    {
+      auto run_exner = [&](Real h) {
+        PerturbedConstants<Real>::perturb = h;
+        Real pnh_h = 0, exner_h = 0;
+        EOS<PerturbedConstants<Real>>::compute_pnh_and_exner(vtheta_dp, dphi, pnh_h, exner_h);
+        PerturbedConstants<Real>::perturb = 0.0;
+        return exner_h;
+      };
+      REQUIRE(check_fad_vs_fd(run_exner, fad_exner_val, fad_dexner_deps, h_vals, "compute_pnh_and_exner::exner"));
+    }
+  }
+
+} // TEST_CASE
 
 } // namespace Homme

--- a/components/homme/test_execs/thetal_kokkos_ut/eos_sacado_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/eos_sacado_ut.cpp
@@ -23,10 +23,10 @@ struct PerturbedConstants {
   static ST perturb;
 
   // Only decl the ones used in EOS
-  static KOKKOS_FORCEINLINE_FUNCTION ST   Rgas  () { return (1+perturb)*PC::Rgas; }
-  static KOKKOS_FORCEINLINE_FUNCTION Real cp    () { return PC::cp;           }
-  static KOKKOS_FORCEINLINE_FUNCTION ST   kappa () { return Rgas() / cp();    }
-  static KOKKOS_FORCEINLINE_FUNCTION Real p0    () { return PC::p0;           }  // [mbar]
+  static KOKKOS_FORCEINLINE_FUNCTION ST             Rgas  () { return (1+perturb)*PC::Rgas; }
+  static KOKKOS_FORCEINLINE_FUNCTION constexpr Real cp    () { return PC::cp;           }
+  static KOKKOS_FORCEINLINE_FUNCTION ST             kappa () { return Rgas() / cp();    }
+  static KOKKOS_FORCEINLINE_FUNCTION constexpr Real p0    () { return PC::p0;           }  // [mbar]
 };
 
 template<typename ST>
@@ -65,6 +65,10 @@ bool check_fad_vs_fd (Func&& run,
   std::cout << "  h   = [" << ekat::join(h_vals,",") << "]\n";
   std::cout << "  |FD-FAD| = [" << ekat::join(fd_errors,",") << "]\n";
 
+  // Require first-order convergence: the minimum FD error must be at least
+  // 100x smaller than the coarsest-h error. With h_vals spanning 1e-2 to 1e-8,
+  // the truncation error drops by ~1e4 before round-off dominates, so the
+  // minimum is well below fd_errors[0]/100.
   const Real min_err = *std::min_element(fd_errors.begin(),fd_errors.end());
   return (min_err < fd_errors[0] / 1e2);
 }

--- a/components/homme/test_execs/thetal_kokkos_ut/eos_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/eos_ut.cpp
@@ -83,7 +83,7 @@ TEST_CASE("eos", "eos") {
   const Real* hyai_ptr = hyai.data();
   init_f90(hyai_ptr,hvcoord.ps0);
 
-  EquationOfState eos;
+  EquationOfState<> eos;
   ElementOps elem_ops;
   elem_ops.init(hvcoord);
 

--- a/components/homme/test_execs/thetal_kokkos_ut/gllfvremap_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/gllfvremap_ut.cpp
@@ -763,7 +763,7 @@ static void test_get_temperature (Session& s) {
                   eos.compute_pnh_and_exner(kv, vthdp_ij, Homme::subview(phi_i,ie,t,i,j), wrk_ij,
                                             exner_ij);
                 }
-                ops.get_temperature(kv, eos, use_moisture, dp3d_ij, exner_ij,
+                ops.get_temperature(kv, use_moisture, dp3d_ij, exner_ij,
                                     vthdp_ij, Homme::subview(q,ie,0,i,j), wrk_ij,
                                     Homme::subview(Td,ie,t,i,j));
               });

--- a/components/homme/test_execs/thetal_kokkos_ut/gllfvremap_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/gllfvremap_ut.cpp
@@ -270,8 +270,8 @@ private:
       ts.flags.erase("planar");
     }
 
-    auto print_key = [](const auto it) {
-      return it->first;
+    auto print_key = [](const auto& it) {
+      return it.first;
     };
     EKAT_REQUIRE_MSG(ts.flags.size()==0,
         "Error! Unrecognized flags: " + ekat::join(ts.flags,print_key,",") + "\n");

--- a/components/homme/test_execs/thetal_kokkos_ut/gllfvremap_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/gllfvremap_ut.cpp
@@ -685,7 +685,7 @@ static void init_dyn_data (Session& s) {
   deep_copy(uv_s, uv);
 
   {
-    EquationOfState eos; eos.init(c.get<SimulationParams>().theta_hydrostatic_mode, s.h);
+    EquationOfState<> eos; eos.init(c.get<SimulationParams>().theta_hydrostatic_mode, s.h);
     ElementOps ops; ops.init(s.h);
     const auto phis = geometry.m_phis;
     const auto dp3d = state.m_dp3d;
@@ -731,7 +731,7 @@ static void test_get_temperature (Session& s) {
     const ExecViewManaged<Scalar*[NUM_TIME_LEVELS][NP][NP][NUM_LEV]> Td("T", s.nelemd); {
       auto& c = Context::singleton();
       const auto& sp = c.get<SimulationParams>();
-      EquationOfState eos; eos.init(theta_hydrostatic_mode, s.h);
+      EquationOfState<> eos; eos.init(theta_hydrostatic_mode, s.h);
       ElementOps ops; ops.init(s.h);
       const bool use_moisture = sp.use_moisture;
       const auto state = c.get<ElementsState>();

--- a/components/homme/test_execs/thetal_kokkos_ut/hv_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/hv_ut.cpp
@@ -478,7 +478,7 @@ TEST_CASE("hvf", "biharmonic") {
 
         constexpr Real noise_lvl = 0.05;
         genRandArray(perturb,engine,PDF(-noise_lvl,noise_lvl));
-        EquationOfState eos;
+        EquationOfState<> eos;
         eos.init(hydrostatic,hvcoord);
 
         ElementOps elem_ops;


### PR DESCRIPTION
Add a struct provider for physics constants (in the form of static methods), which different parts of the library can use instead of the plain PhysicsConstants namespace. The default impl of the constants provider is to simply return the constexpr constants as Real's.

We start using this in EquationOfState, which changes slightly its API. We then implement a version of the provider that allows for a perturbation (either as a real or fad type), and verify that EOS fcns are correctly differentiated by sacado comparing against finite differences.