### PR TITLE
Create unit tests for Dirk for sacado derivatives

### DIFF
--- a/components/homme/src/preqx_kokkos/cxx/ElementsState.hpp
+++ b/components/homme/src/preqx_kokkos/cxx/ElementsState.hpp
@@ -55,12 +55,12 @@ public:
 
   HashType hash(const int time_level) const;
 
+  // Not implemented.
+  void check_print_abort_on_bad_elems(const std::string& /* label */,
+                                      const int /* time_level */) const {}
 private:
   int m_num_elems;
 };
-
-// Not implemented.
-void check_print_abort_on_bad_elems(const std::string& label, const int time_level);
 
 using ElementsState = ElementsStateST<ScalarValue>;
 

--- a/components/homme/src/preqx_kokkos/cxx/ElementsState_def.hpp
+++ b/components/homme/src/preqx_kokkos/cxx/ElementsState_def.hpp
@@ -179,11 +179,6 @@ void ElementsStateST<ST>::push_to_f90_pointers (F90Ptr& state_v, F90Ptr& state_t
   sync_to_host(m_v,    state_v_f90);
 }
 
-void check_print_abort_on_bad_elems (const std::string& label, const int time_level) {
-  // Not implemented.
-  return;
-}
-
 template<typename ST>
 HashType ElementsStateST<ST>::hash (const int) const { return 0; }
 

--- a/components/homme/src/preqx_kokkos/cxx/ElementsState_def.hpp
+++ b/components/homme/src/preqx_kokkos/cxx/ElementsState_def.hpp
@@ -20,7 +20,7 @@
 namespace Homme {
 
 template<typename ST>
-void ElementsState<ST>::init(const int num_elems) {
+void ElementsStateST<ST>::init(const int num_elems) {
   // Sanity check
   assert (num_elems>0);
 
@@ -34,17 +34,17 @@ void ElementsState<ST>::init(const int num_elems) {
 }
 
 template<typename ST>
-void ElementsState<ST>::randomize(const int seed) {
+void ElementsStateST<ST>::randomize(const int seed) {
   randomize(seed,1.0);
 }
 
 template<typename ST>
-void ElementsState<ST>::randomize(const int seed, const Real max_pressure) {
+void ElementsStateST<ST>::randomize(const int seed, const Real max_pressure) {
   randomize(seed,max_pressure,max_pressure/100, 0.0);
 }
 
 template<typename ST>
-void ElementsState<ST>::randomize(const int seed, const Real max_pressure, const Real ps0, const Real hyai0) {
+void ElementsStateST<ST>::randomize(const int seed, const Real max_pressure, const Real ps0, const Real hyai0) {
   // Check state was inited
   assert (m_num_elems>0);
 
@@ -149,7 +149,7 @@ void ElementsState<ST>::randomize(const int seed, const Real max_pressure, const
 }
 
 template<typename ST>
-void ElementsState<ST>::pull_from_f90_pointers (CF90Ptr& state_v,    CF90Ptr& state_t,
+void ElementsStateST<ST>::pull_from_f90_pointers (CF90Ptr& state_v,    CF90Ptr& state_t,
                                             CF90Ptr& state_dp3d, CF90Ptr& state_ps_v) {
   HostViewUnmanaged<const Real *[NUM_TIME_LEVELS][NUM_PHYSICAL_LEV]   [NP][NP]> state_t_f90    (state_t,m_num_elems);
   HostViewUnmanaged<const Real *[NUM_TIME_LEVELS][NUM_PHYSICAL_LEV]   [NP][NP]> state_dp3d_f90 (state_dp3d,m_num_elems);
@@ -169,7 +169,7 @@ void ElementsState<ST>::pull_from_f90_pointers (CF90Ptr& state_v,    CF90Ptr& st
 }
 
 template<typename ST>
-void ElementsState<ST>::push_to_f90_pointers (F90Ptr& state_v, F90Ptr& state_t, F90Ptr& state_dp3d) const {
+void ElementsStateST<ST>::push_to_f90_pointers (F90Ptr& state_v, F90Ptr& state_t, F90Ptr& state_dp3d) const {
   HostViewUnmanaged<Real *[NUM_TIME_LEVELS][NUM_PHYSICAL_LEV]   [NP][NP]> state_t_f90    (state_t,m_num_elems);
   HostViewUnmanaged<Real *[NUM_TIME_LEVELS][NUM_PHYSICAL_LEV]   [NP][NP]> state_dp3d_f90 (state_dp3d,m_num_elems);
   HostViewUnmanaged<Real *[NUM_TIME_LEVELS][NUM_PHYSICAL_LEV][2][NP][NP]> state_v_f90    (state_v,m_num_elems);
@@ -185,7 +185,7 @@ void check_print_abort_on_bad_elems (const std::string& label, const int time_le
 }
 
 template<typename ST>
-HashType ElementsState<ST>::hash (const int) const { return 0; }
+HashType ElementsStateST<ST>::hash (const int) const { return 0; }
 
 } // namespace Homme
 

--- a/components/homme/src/share/cxx/RemapFunctor.hpp
+++ b/components/homme/src/share/cxx/RemapFunctor.hpp
@@ -328,7 +328,7 @@ struct RemapFunctor : public Remapper {
       }
     }
     if ( ! ok) {
-      check_print_abort_on_bad_elems(
+      m_state.check_print_abort_on_bad_elems(
         "Vertical remap: Negative (or nan) layer thickness detected, aborting!",
         m_data.np1);
       // If check_print_abort_on_bad_elems can't see the issue -- e.g., if the

--- a/components/homme/src/share/cxx/utilities/MathUtils.hpp
+++ b/components/homme/src/share/cxx/utilities/MathUtils.hpp
@@ -14,6 +14,20 @@
 namespace Homme
 {
 
+#ifdef HOMMEXX_ENABLE_FAD_TYPES
+template <typename T>
+KOKKOS_INLINE_FUNCTION
+auto eval(const T& x) -> typename Sacado::Promote<T,T>::type {
+    return x;
+}
+#else
+template <typename T>
+KOKKOS_INLINE_FUNCTION
+T eval(const T& x) {
+    return x;
+}
+#endif
+
 template <typename FPType>
 KOKKOS_INLINE_FUNCTION constexpr FPType min(const FPType val_1,
                                             const FPType val_2) {
@@ -37,7 +51,7 @@ KOKKOS_INLINE_FUNCTION constexpr FPType max(const FPType val, FPPack... pack) {
 }
 
 template <typename FPType>
-KOKKOS_INLINE_FUNCTION constexpr FPType square(const FPType& x) {
+KOKKOS_INLINE_FUNCTION constexpr auto square(const FPType& x) {
   return x*x;
 }
 

--- a/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
@@ -350,7 +350,7 @@ struct CaarFunctorImplST {
     Kokkos::fence();
     GPTLstop("caar compute");
     if (nerr > 0)
-      check_print_abort_on_bad_elems("CaarFunctorImpl::run TagPreExchange", data.n0);
+      m_state.check_print_abort_on_bad_elems("CaarFunctorImpl::run TagPreExchange", data.n0);
   }
 
   void run (const RKStageData& data)
@@ -365,7 +365,7 @@ struct CaarFunctorImplST {
     Kokkos::fence();
     GPTLstop("caar compute");
     if (nerr > 0)
-      check_print_abort_on_bad_elems("CaarFunctorImpl::run TagPreExchange", data.n0);
+      m_state.check_print_abort_on_bad_elems("CaarFunctorImpl::run TagPreExchange", data.n0);
 
     GPTLstart("caar_bexchV");
     m_bes[data.np1]->exchange(m_geometry.m_rspheremp);

--- a/components/homme/src/theta-l_kokkos/cxx/DirkFunctor.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/DirkFunctor.hpp
@@ -10,12 +10,11 @@
 #include "Elements.hpp"
 #include "Types.hpp"
 #include <memory>
+#include <any>
 
 namespace Homme {
 
 class FunctorsBuffersManager;
-template<typename ST>
-class DirkFunctorImplST;
 
 class HybridVCoord;
 
@@ -36,7 +35,7 @@ public:
            const ElementsST<ST>& elements, const HybridVCoord& hvcoord);
 
 private:
-  std::unique_ptr<DirkFunctorImplST<ST>> m_dirk_impl;
+  std::any m_dirk_impl;
 };
 
 using DirkFunctor = DirkFunctorST<ScalarValue>;

--- a/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
@@ -407,7 +407,7 @@ struct DirkFunctorImplST {
       const int nt[] = {nm1, n0, np1};
       const char* ntname[] = {"nm1", "n0", "np1"};
       for (int i = 0; i < 3; ++i)
-        check_print_abort_on_bad_elems(std::string("DIRK Newton loop ") + ntname[i], nt[i]);
+        e.m_state.check_print_abort_on_bad_elems(std::string("DIRK Newton loop ") + ntname[i], nt[i]);
     }
   }
 

--- a/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
@@ -91,6 +91,7 @@ struct DirkFunctorImplST {
   TeamPolicy m_policy, m_ig_policy;
   TeamUtils<ExecSpace> m_tu, m_tu_ig;
   int nslot;
+  bool m_verbose = true; // Set to false to suppress some warnings in unit tests
 
   DirkFunctorImplST (const int nelem)
     : m_policy(1,1,1), m_ig_policy(1,1,1), m_tu(m_policy), m_tu_ig(m_ig_policy) // throwaway settings
@@ -232,6 +233,7 @@ struct DirkFunctorImplST {
     const auto tu   = m_tu;
 
     EquationOfState<> eos;
+    const auto verbose = m_verbose;
     const auto toplevel = KOKKOS_LAMBDA (const MT& team, int& nerr) {
       KernelVariables kv(team, tu);
       const auto ie = kv.ie;
@@ -386,7 +388,7 @@ struct DirkFunctorImplST {
       } // Newton iteration
       kv.team_barrier();
 
-      if (it >= maxiter) {
+      if (it >= maxiter and verbose) {
         Kokkos::printf("[DIRK] WARNING! Newton reached max iteration count,"
                        " with deltaerr = %3.17f\n", ADValue(deltaerr));
         nerr = 1;

--- a/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
@@ -24,7 +24,7 @@
 
 namespace Homme {
 
-template<typename ST>
+template<typename ST, typename Constants = PhysicalConstantsProvider>
 struct DirkFunctorImplST {
   using PT = PackType<ST>;
 
@@ -92,6 +92,7 @@ struct DirkFunctorImplST {
   TeamUtils<ExecSpace> m_tu, m_tu_ig;
   int nslot;
   bool m_verbose = true; // Set to false to suppress some warnings in unit tests
+  EquationOfState<Constants> m_eos;
 
   DirkFunctorImplST (const int nelem)
     : m_policy(1,1,1), m_ig_policy(1,1,1), m_tu(m_policy), m_tu_ig(m_ig_policy) // throwaway settings
@@ -171,7 +172,7 @@ struct DirkFunctorImplST {
     const auto work = m_work;
     const auto tu   = m_tu_ig;
 
-    EquationOfState<> eos;
+    auto eos = m_eos;
     const auto toplevel = KOKKOS_LAMBDA (const MT& team) {
       KernelVariables kv(team, tu);
       const auto ie = kv.ie;
@@ -210,7 +211,7 @@ struct DirkFunctorImplST {
     using Kokkos::parallel_for;
     const auto a = Kokkos::ALL();
 
-    const auto grav = PhysicalConstants::g;
+    const auto grav = m_eos.m_constants.g();
     const int nvec = npack;
     const int maxiter = 20;
 #ifdef HOMMEXX_BFB_TESTING
@@ -231,9 +232,10 @@ struct DirkFunctorImplST {
     const auto e_initial_guess = e.m_derived.m_divdp_proj;
     const auto hybi = hvcoord.hybrid_bi;
     const auto tu   = m_tu;
-
-    EquationOfState<> eos;
+    const auto eos = m_eos;
+    const auto constants = eos.m_constants;
     const auto verbose = m_verbose;
+
     const auto toplevel = KOKKOS_LAMBDA (const MT& team, int& nerr) {
       KernelVariables kv(team, tu);
       const auto ie = kv.ie;
@@ -334,7 +336,7 @@ struct DirkFunctorImplST {
       kv.team_barrier();
       // If any dphi > -g in a column, set it to -g and integrate to get a
       // new initial phi_np1 and w_np1.
-      calc_whether_gt_and_set(kv, nlev, nvec, -grav, dphi, wrk);
+      calc_whether_gt_and_set(kv, nlev, nvec, -ADValue(grav), dphi, wrk);
       kv.team_barrier();
       if (wrk(1,0)[0] == 1) {
         scan_dphi(kv, nlev, nvec, wrk, dphi, phi_np1);
@@ -357,7 +359,7 @@ struct DirkFunctorImplST {
           x(k,i) = -(w_np1(k,i) - (w_n0(k,i) + grav*dt2*(dpnh_dp_i(k,i) - 1))); // -residual
         });
 
-        calc_jacobian(kv, dt2, dp3d, dphi, pnh, dl, d, du);
+        calc_jacobian(kv, constants, dt2, dp3d, dphi, pnh, dl, d, du);
         kv.team_barrier();
         if (bfb_solver) solvebfb(kv, dl, d, du, x); else solve(kv, dl, d, du, x);
         kv.team_barrier();
@@ -565,7 +567,7 @@ struct DirkFunctorImplST {
   KOKKOS_INLINE_FUNCTION static
   bool pnh_and_exner_from_eos (
     const KernelVariables& kv, const HybridVCoord& hvcoord,
-    const EquationOfState<>& eos,
+    const EquationOfState<Constants>& eos,
     // All arrays are in DIRK format.
     const R& vtheta_dp, const R& dp3d, const R& dphi,
     // exner is workspace. dpnh_dp_i(nlevp,:) is not computed.
@@ -625,7 +627,7 @@ struct DirkFunctorImplST {
   // parallelization.
   template <typename Rphis, typename R, typename W>
   KOKKOS_INLINE_FUNCTION static void
-  phi_from_eos (const KernelVariables& kv, const EquationOfState<>& eos,
+  phi_from_eos (const KernelVariables& kv, const EquationOfState<Constants>& eos,
                 const int nlev, const int nvec,
                 const HybridVCoord& hvcoord, const Rphis& phis, const R& vtheta_dp, const R& dp,
                 // phi_i on output
@@ -724,7 +726,7 @@ struct DirkFunctorImplST {
   */
   template <typename R, typename W>
   KOKKOS_INLINE_FUNCTION
-  static void calc_jacobian (const KernelVariables& kv, const Real& dt2,
+  static void calc_jacobian (const KernelVariables& kv, const Constants& constants, const Real& dt2,
                              // All arrays are in DIRK format.
                              const R& dp3d, const R& dphi, const R& pnh,
                              const W& dl, const W& d, const W& du,
@@ -735,7 +737,11 @@ struct DirkFunctorImplST {
     const auto pv = Kokkos::ThreadVectorRange(kv.team, n);
     const auto pt1 = Kokkos::TeamThreadRange(kv.team, 1);
 
-    const Real a = square(dt2*PhysicalConstants::g)/(1 - PhysicalConstants::kappa);
+    const auto g = constants.g();
+    const auto kappa = constants.kappa();
+    // If the input is a Sacado expression, eval will evaluate and return the resulting Fad.
+    const auto a = eval(square(dt2*g) / (1-kappa));
+    // std::cout << "typeid(a)=" << typeid(a).name() << ", a=" << a << "\n";
 
     const auto f1 = [&] (const int) {
       const auto ks = [&] (const int i) { // first Jacobian row
@@ -800,9 +806,10 @@ struct DirkFunctorImplST {
   }
 
   // Determine a step length 0 < alpha <= 1.
+  template<typename GravST>
   KOKKOS_INLINE_FUNCTION static void
   calc_step_size (const KernelVariables& kv, const int nlev, const int nvec,
-                  const Real& grav, const Real& dt2,
+                  const GravST& grav, const Real& dt2,
                   const WorkSlot& dphi_n0, const WorkSlot& w_np1, const LinearSystemSlot& x,
                   // On input, wrk(0,i)[s] is 1 if the step length should be
                   // smaller. On output, alpha is in wrk(2,:).

--- a/components/homme/src/theta-l_kokkos/cxx/DirkFunctor_def.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/DirkFunctor_def.hpp
@@ -19,8 +19,9 @@
 namespace Homme {
 
 template<typename ST>
-DirkFunctorST<ST>::DirkFunctorST (int nelem) {
-  m_dirk_impl.reset(new DirkFunctorImplST<ST>(nelem));
+DirkFunctorST<ST>::DirkFunctorST (int nelem)
+{
+  m_dirk_impl = DirkFunctorImplST<ST>(nelem);
 }
 
 // Note: you cannot declare the default destructor in the header,
@@ -33,12 +34,14 @@ DirkFunctorST<ST>::~DirkFunctorST () = default;
 
 template<typename ST>
 int DirkFunctorST<ST>::requested_buffer_size () const {
-  return m_dirk_impl->requested_buffer_size();
+  // NOTE: the cast always works, since we created m_dirk_impl in the ctor with that type
+  return std::any_cast<DirkFunctorImplST<ST>>(&m_dirk_impl)->requested_buffer_size();
 }
 
 template<typename ST>
 void DirkFunctorST<ST>::init_buffers (const FunctorsBuffersManager& fbm) {
-  m_dirk_impl->init_buffers(fbm);
+  // NOTE: the cast always works, since we created m_dirk_impl in the ctor with that type
+  std::any_cast<DirkFunctorImplST<ST>>(&m_dirk_impl)->init_buffers(fbm);
 }
 
 template<typename ST>
@@ -46,7 +49,9 @@ void DirkFunctorST<ST>::
 run (int nm1, Real alphadt_nm1, int n0, Real alphadt_n0, int np1, Real dt2,
      const ElementsST<ST>& elements, const HybridVCoord& hvcoord) {
   GPTLstart("compute_stage_value_dirk");
-  m_dirk_impl->run(nm1, alphadt_nm1, n0, alphadt_n0, np1, dt2, elements, hvcoord);
+  // NOTE: the cast always works, since we created m_dirk_impl in the ctor with that type
+  auto impl = std::any_cast<DirkFunctorImplST<ST>>(&m_dirk_impl);
+  impl->run(nm1, alphadt_nm1, n0, alphadt_n0, np1, dt2, elements, hvcoord);
   GPTLstop("compute_stage_value_dirk");
 }
 

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
@@ -87,6 +87,15 @@ public:
   template<typename RST>
   void import_values (const ElementsStateST<RST>& rhs, int tl);
 
+  // Check ElementsState for NaN or incorrectly signed values. The initial check
+  // is fast and on device. If everything is fine, the routine returns
+  // immediately. If there is a bad value, a subsequent check is run on the host,
+  // and this check prints detailed information to a file called
+  // hommexx.errlog.${rank}. Then EKAT_ERROR_MSG is called with a message pointing
+  // to this file.
+  void check_print_abort_on_bad_elems(const std::string& label,    // string to ID call site
+                                      const int time_level) const; // time level index in state arrays
+
 
 #ifdef HOMMEXX_ENABLE_FAD_TYPES
   void randomize_derivs(const int seed, const int itl);
@@ -192,15 +201,6 @@ ElementsStateST<ST>::import_values_from_deriv (const ElementsStateST<RST>& rhs, 
   Kokkos::parallel_for(p,copy);
 }
 #endif // HOMMEXX_ENABLE_FAD_TYPES
-
-// Check ElementsState for NaN or incorrectly signed values. The initial check
-// is fast and on device. If everything is fine, the routine returns
-// immediately. If there is a bad value, a subsequent check is run on the host,
-// and this check prints detailed information to a file called
-// hommexx.errlog.${rank}. Then EKAT_ERROR_MSG is called with a message pointing
-// to this file.
-void check_print_abort_on_bad_elems(const std::string& label,    // string to ID call site
-                                    const int time_level);        // time level index in state arrays
 
 } // Homme
 

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState_def.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState_def.hpp
@@ -435,26 +435,23 @@ static bool all_good_elems (const ElementsStateST<ST>& s, const int tlvl) {
   const int nelem = s.num_elems();
   const int nplev = NUM_PHYSICAL_LEV;
 
-  const auto vtheta_dp = Kokkos::subview(s.m_vtheta_dp, ALL, tlvl, ALL, ALL, ALL);
-  const auto dp3d = Kokkos::subview(s.m_dp3d, ALL, tlvl, ALL, ALL, ALL);
-  const auto phinh_i = Kokkos::subview(s.m_phinh_i, ALL, tlvl, ALL, ALL, ALL);
-
   // Write nerr = 1 if there is a problem; else do nothing.
   const auto check = KOKKOS_LAMBDA (const TeamMember& team, int& nerr) {
     const auto ie = team.league_rank();
     const auto g = [&] (const int idx) {
       const int igp = idx / NP;
       const int jgp = idx % NP;
-      const Real* const v = reinterpret_cast<const Real*>(&vtheta_dp(ie,igp,jgp,0));
-      const Real* const p = reinterpret_cast<const Real*>(&     dp3d(ie,igp,jgp,0));
-      const Real* const h = reinterpret_cast<const Real*>(&  phinh_i(ie,igp,jgp,0));
+
+      auto v = ekat::scalarize(Homme::subview(s.m_vtheta_dp,ie,tlvl,igp,jgp));
+      auto p = ekat::scalarize(Homme::subview(s.m_dp3d,ie,tlvl,igp,jgp));
+      auto h = ekat::scalarize(Homme::subview(s.m_phinh_i,ie,tlvl,igp,jgp));
       // Write races but doesn't matter since any single nerr = 1 write is
       // sufficient to conclude there is a problem.
-      const auto f1 = [&] (const int k) { if (v[k] < 0 || isnan(v[k])) nerr = 1; };
-      const auto f2 = [&] (const int k) { if (p[k] < 0 || isnan(p[k])) nerr = 1; };
+      const auto f1 = [&] (const int k) { if (v[k] < 0 || isnan(ADValue(v[k]))) nerr = 1; };
+      const auto f2 = [&] (const int k) { if (p[k] < 0 || isnan(ADValue(p[k]))) nerr = 1; };
       // The isnan checks on k and k+1 are redundant except for the last k, but
       // it's probably the fastest way to check all interface values.
-      const auto f3 = [&] (const int k) { if (h[k] < h[k+1] || isnan(h[k]) || isnan(h[k+1])) nerr = 1; };
+      const auto f3 = [&] (const int k) { if (h[k] < h[k+1] || isnan(ADValue(h[k])) || isnan(ADValue(h[k+1]))) nerr = 1; };
       const auto tvr = Kokkos::ThreadVectorRange(team, nplev);
       parallel_for(tvr, f1);
       parallel_for(tvr, f2);
@@ -468,31 +465,35 @@ static bool all_good_elems (const ElementsStateST<ST>& s, const int tlvl) {
   return nerr == 0;
 }
 
-void check_print_abort_on_bad_elems (const std::string& label, const int tlvl) {
-  const auto& s = Context::singleton().get<ElementsState>();
-
+template<typename ST>
+void ElementsStateST<ST>::
+check_print_abort_on_bad_elems (const std::string& label, const int tlvl) const
+{
   // On device and, thus, efficient.
-  if (all_good_elems(s, tlvl)) return;
+  if (all_good_elems(*this, tlvl)) return;
 
   // Now that we know there is an error, we can do the rest inefficiently.
-  const auto& geometry = Context::singleton().get<ElementsGeometry>();
-  const int nelem = s.num_elems();
+  const int nelem = num_elems();
   const int nplev = NUM_PHYSICAL_LEV, ntl = NUM_TIME_LEVELS, vecsz = VECTOR_SIZE;
-  const auto& comm = Context::singleton().get<Connectivity>().get_comm();
+  const auto& comm = Context::singleton().get<ekat::Comm>();
+  const auto& geometry = Context::singleton().get<ElementsGeometry>();
 
-  const auto vtheta_dp_h = Kokkos::create_mirror_view(s.m_vtheta_dp);
-  Kokkos::deep_copy(vtheta_dp_h, s.m_vtheta_dp);
-  const auto dp3d_h = Kokkos::create_mirror_view(s.m_dp3d);
-  Kokkos::deep_copy(dp3d_h, s.m_dp3d);
-  const auto phinh_i_h = Kokkos::create_mirror_view(s.m_phinh_i);
-  Kokkos::deep_copy(phinh_i_h, s.m_phinh_i);
+  const auto vtheta_dp_h = Kokkos::create_mirror_view(m_vtheta_dp);
+  Kokkos::deep_copy(vtheta_dp_h, m_vtheta_dp);
+  const auto dp3d_h = Kokkos::create_mirror_view(m_dp3d);
+  Kokkos::deep_copy(dp3d_h, m_dp3d);
+  const auto phinh_i_h = Kokkos::create_mirror_view(m_phinh_i);
+  Kokkos::deep_copy(phinh_i_h, m_phinh_i);
   const auto sphere_latlon = Kokkos::create_mirror_view(geometry.m_sphere_latlon);
   Kokkos::deep_copy(sphere_latlon, geometry.m_sphere_latlon);
 
-  HostView<Real*****>
-    vtheta_dp(reinterpret_cast<Real*>(&vtheta_dp_h(0,0,0,0,0)), nelem, ntl, NP, NP, NUM_LEV  *vecsz),
-    dp3d     (reinterpret_cast<Real*>(&dp3d_h     (0,0,0,0,0)), nelem, ntl, NP, NP, NUM_LEV  *vecsz),
-    phinh_i  (reinterpret_cast<Real*>(&phinh_i_h  (0,0,0,0,0)), nelem, ntl, NP, NP, NUM_LEV_P*vecsz);
+  auto vtheta_dp = ekat::scalarize(vtheta_dp_h);
+  auto dp3d      = ekat::scalarize(dp3d_h);
+  auto phinh_i   = ekat::scalarize(phinh_i_h);
+
+  auto isnan = [](auto val) {
+    return std::isnan(ADValue(val));
+  };
 
   bool first = true;
   FILE* fid = nullptr;
@@ -503,9 +504,9 @@ void check_print_abort_on_bad_elems (const std::string& label, const int tlvl) {
         int k_bad = -1;
         bool v = true, d = true, p = true;
         for (int k = 0; k < nplev; ++k) {
-          v = std::isnan(vtheta_dp(ie,tlvl,gi,gj,k)) || vtheta_dp(ie,tlvl,gi,gj,k) < 0;
-          d = std::isnan(dp3d(ie,tlvl,gi,gj,k)) || dp3d(ie,tlvl,gi,gj,k) < 0;
-          p = (std::isnan(phinh_i(ie,tlvl,gi,gj,k)) || std::isnan(phinh_i(ie,tlvl,gi,gj,k+1)) ||
+          v = isnan(vtheta_dp(ie,tlvl,gi,gj,k)) || vtheta_dp(ie,tlvl,gi,gj,k) < 0;
+          d = isnan(dp3d(ie,tlvl,gi,gj,k)) || dp3d(ie,tlvl,gi,gj,k) < 0;
+          p = (isnan(ADValue(phinh_i(ie,tlvl,gi,gj,k))) || isnan(ADValue(phinh_i(ie,tlvl,gi,gj,k+1))) ||
                phinh_i(ie,tlvl,gi,gj,k) < phinh_i(ie,tlvl,gi,gj,k+1));
           if (v || d || p) {
             k_bad = k;

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState_def.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState_def.hpp
@@ -21,6 +21,7 @@
 #include <ekat_comm.hpp>
 
 #include <limits>
+#include <cmath>
 #include <random>
 #include <assert.h>
 
@@ -93,25 +94,26 @@ void ElementsStateST<ST>::randomize(const int seed,
 
   auto h_phis = Kokkos::create_mirror_view(phis);
   Kokkos::deep_copy(h_phis,phis);
+  auto phinh_h = Kokkos::create_mirror_view(m_phinh_i);
+  Real phi_top = 1e5;
+  std::uniform_real_distribution<Real> pdf_dphi (0.7,1.3);
   for (int ie=0; ie<m_num_elems; ++ie) {
     for (int igp=0; igp<NP; ++igp) {
       for (int jgp=0; jgp<NP; ++ jgp) {
         const Real phis_ij = h_phis(ie,igp,jgp);
-        // Ensure generated values are larger than phis
-        std::uniform_real_distribution<Real> random_dist(1.001*phis_ij,100.0*phis_ij);
+        Real dphi_mean = (phi_top - phis_ij) / NUM_PHYSICAL_LEV;
         for (int itl=0; itl<NUM_TIME_LEVELS; ++itl) {
           // Get column
-          auto phi_col = ekat::scalarize(Homme::subview(m_phinh_i,ie,itl,igp,jgp));
-
-          // Generate values
-          genRandArray(phi_col,engine,random_dist,sort_and_chek);
-
-          // Stuff phis at the bottom
-          Kokkos::deep_copy(Kokkos::subview(phi_col,NUM_PHYSICAL_LEV),phis_ij);
+          auto phi_col = ekat::scalarize(Homme::subview(phinh_h,ie,itl,igp,jgp));
+          phi_col(NUM_PHYSICAL_LEV) = phis_ij;
+          for (int k=NUM_PHYSICAL_LEV; k>0; --k) {
+            phi_col(k-1) = phi_col(k) + dphi_mean*pdf_dphi(engine);
+          }
         }
       }
     }
   }
+  Kokkos::deep_copy(m_phinh_i,phinh_h);
 }
 
 template<typename ST>
@@ -248,8 +250,9 @@ void ElementsStateST<ST>::randomize(const int seed,
 }
 
 template<typename ST>
-void ElementsStateST<ST>::randomize(const int seed,
-                              const HybridVCoord& hvcoord) {
+void ElementsStateST<ST>::
+randomize(const int seed, const HybridVCoord& hvcoord)
+{
   // Check elements were inited
   assert (m_num_elems>0);
 
@@ -257,40 +260,57 @@ void ElementsStateST<ST>::randomize(const int seed,
   assert (hvcoord.ps0>0);
   assert (hvcoord.hybrid_ai0>=0);
 
-  // Arbitrary minimum value to generate
-  constexpr const Real min_value = 0.015625;
-
   std::mt19937_64 engine(seed);
-  std::uniform_real_distribution<Real> random_dist(min_value, 1.0 / min_value);
+  std::uniform_real_distribution<Real> pdf_v(-100,100);
+  std::uniform_real_distribution<Real> pdf_w(-10,10);
   std::uniform_real_distribution<Real> pdf_vtheta_dp(100.0, 1000.0);
 
-  genRandArray(m_v,         engine, random_dist);
-  genRandArray(m_w_i,       engine, random_dist);
+  genRandArray(m_v,         engine, pdf_v);
+  genRandArray(m_w_i,       engine, pdf_w);
   genRandArray(m_vtheta_dp, engine, pdf_vtheta_dp);
-  // Note: to avoid errors in the equation of state, we need phi to be increasing.
-  //       Rather than using a constraint (which may call the function many times,
-  //       we simply ask that there are no duplicates, then we sort it later.
-  auto sort_and_chek = [](const auto& vh)->bool {
-    auto* start = vh.data();
-    auto* end   = vh.data() + vh.size();
-    std::sort(start,end);
-    std::reverse(start,end);
-    auto it = std::unique(start,end);
-    return it==end;
-  };
+  std::uniform_real_distribution<Real> pressure_pdf(800, 1200);
+  genRandArray(m_ps_v, engine, pressure_pdf);
+
+  // Build phi_i from random perturbations around a physically consistent dphi profile.
+  // This keeps the "increment-based" randomization while avoiding pathological
+  // dphi magnitudes that can trigger non-finite values in forcing unit tests.
+  auto ps_h = Kokkos::create_mirror_view(m_ps_v);
+  auto vtheta_h = Kokkos::create_mirror_view(m_vtheta_dp);
+  auto am_h = Kokkos::create_mirror_view(hvcoord.hybrid_am);
+  auto bm_h = Kokkos::create_mirror_view(hvcoord.hybrid_bm);
+  auto phinh_h = Kokkos::create_mirror_view(m_phinh_i);
+  Kokkos::deep_copy(ps_h,m_ps_v);
+  Kokkos::deep_copy(vtheta_h,m_vtheta_dp);
+  Kokkos::deep_copy(am_h,hvcoord.hybrid_am);
+  Kokkos::deep_copy(bm_h,hvcoord.hybrid_bm);
+
+  std::uniform_real_distribution<Real> pdf_dphi (0.7,1.3);
+  constexpr Real phis = 0;
+  constexpr Real eps = std::numeric_limits<Real>::epsilon();
   for (int ie=0; ie<m_num_elems; ++ie) {
     for (int itl=0; itl<NUM_TIME_LEVELS; ++itl) {
       for (int igp=0; igp<NP; ++igp) {
-        for (int jgp=0; jgp<NP; ++ jgp) {
-          auto col = ekat::scalarize(Homme::subview(m_phinh_i,ie,itl,igp,jgp));
-          genRandArray(col,engine,random_dist,sort_and_chek);
+        for (int jgp=0; jgp<NP; ++jgp) {
+          auto phi_col = ekat::scalarize(Homme::subview(phinh_h,ie,itl,igp,jgp));
+          phi_col(NUM_PHYSICAL_LEV) = phis;
+
+          const Real ps = ADValue(ps_h(ie,itl,igp,jgp));
+          for (int k=NUM_PHYSICAL_LEV; k>0; --k) {
+            const int ilev = (k-1) / VECTOR_SIZE;
+            const int ivec = (k-1) % VECTOR_SIZE;
+            const Real p_mid = hvcoord.ps0*am_h(ilev)[ivec] + ps*bm_h(ilev)[ivec];
+            const Real p_safe = std::max(p_mid,eps);
+            const Real vtheta_dp = ADValue(vtheta_h(ie,itl,igp,jgp,ilev)[ivec]);
+            const Real dphi_ref = (PhysicalConstants::Rgas*vtheta_dp
+                                 * std::pow(p_safe/PhysicalConstants::p0,PhysicalConstants::kappa-1))
+                                 / PhysicalConstants::p0;
+            phi_col(k-1) = phi_col(k) + pdf_dphi(engine)*dphi_ref;
+          }
         }
       }
     }
   }
-
-  std::uniform_real_distribution<Real> pressure_pdf(800, 1200);
-  genRandArray(m_ps_v, engine, pressure_pdf);
+  Kokkos::deep_copy(m_phinh_i,phinh_h);
 
   auto dp = m_dp3d;
   auto ps = m_ps_v;

--- a/components/homme/test_execs/thetal_kokkos_ut/CMakeLists.txt
+++ b/components/homme/test_execs/thetal_kokkos_ut/CMakeLists.txt
@@ -385,4 +385,12 @@ if (HOMMEXX_ENABLE_FAD_TYPES)
     LIBS thetal_kokkos_ut_lib
     LABELS AMDIS
   )
+
+  # Tridiag sacado derivatives tests
+  EkatCreateUnitTest ("tridiag_sacado_ut"
+    tridiag_sacado_ut.cpp
+    COMPILER_CXX_DEFS
+    LIBS thetal_kokkos_ut_lib
+    LABELS AMDIS
+  )
 endif()

--- a/components/homme/test_execs/thetal_kokkos_ut/CMakeLists.txt
+++ b/components/homme/test_execs/thetal_kokkos_ut/CMakeLists.txt
@@ -381,7 +381,15 @@ if (HOMMEXX_ENABLE_FAD_TYPES)
   # Eqn of state sacado derivatives tests
   EkatCreateUnitTest (eos_sacado_ut
     eos_sacado_ut.cpp
-    COMPILER_CXX_DEFS HOMMEXX_SPHERE_OP_ST_FACTORS
+    COMPILER_CXX_DEFS
+    LIBS thetal_kokkos_ut_lib
+    LABELS AMDIS
+  )
+
+  # Dirk sacado derivatives tests
+  EkatCreateUnitTest ("dirk_sacado_ut"
+    "dirk_sacado_ut.cpp;${SHARE_UT_DIR}/geometry_interface.F90;thetal_test_interface.F90"
+    COMPILER_CXX_DEFS
     LIBS thetal_kokkos_ut_lib
     LABELS AMDIS
   )

--- a/components/homme/test_execs/thetal_kokkos_ut/dirk_sacado_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/dirk_sacado_ut.cpp
@@ -1,0 +1,207 @@
+#include <catch2/catch.hpp>
+
+#include "DirkFunctorImpl.hpp"
+
+#include <random>
+
+#include "Types.hpp"
+#include "Context.hpp"
+#include "mpi/Connectivity.hpp"
+#include "SimulationParams.hpp"
+#include "Elements.hpp"
+#include "PhysicalConstants.hpp"
+
+#include "utilities/TestUtils.hpp"
+#include "utilities/SyncUtils.hpp"
+#include "utilities/ViewUtils.hpp"
+
+#include <ekat_string_utils.hpp>
+#include <ekat_test_utils.hpp>
+
+#include <iomanip>
+
+using namespace Homme;
+
+// A constants provider that perturbs Rgas by a factor (1+perturb).
+// kappa = Rgas/cp is also perturbed as a result.
+template<typename ST>
+struct PerturbedConstants : public PhysicalConstantsProvider {
+  using PC = PhysicalConstantsProvider;
+
+  PerturbedConstants() = default;
+
+  ST perturb = 0;
+
+  // Only redefine the ones we want to perturb (the rest is inherited)
+  KOKKOS_FORCEINLINE_FUNCTION ST Rgas  () const { return (1+perturb)*PC::Rgas(); }
+  KOKKOS_FORCEINLINE_FUNCTION ST kappa () const { return Rgas() / cp();    }
+};
+
+TEST_CASE ("dirk_dp_testing")
+{
+  // Setup random number generator
+  std::random_device rd;
+  const unsigned int catchRngSeed = Catch::rngSeed();
+  const unsigned int seed = catchRngSeed==0 ? rd() : catchRngSeed;
+  std::cout << "seed: " << seed << (catchRngSeed==0 ? " (catch rng seed was 0)\n" : "\n");
+
+  using rpdf = std::uniform_real_distribution<Real>;
+  using ipdf = std::uniform_int_distribution<int>;
+  using rngAlg = std::mt19937_64;
+
+  rngAlg engine(seed);
+
+  // Create data structures
+  Context::finalize_singleton();
+  Context::singleton().create<ekat::Comm>(MPI_COMM_WORLD);
+
+  const auto ALL = Kokkos::ALL;
+  const int ntl = NUM_TIME_LEVELS;
+  const int nlev = NUM_PHYSICAL_LEV;
+  const int np = NP;
+
+  auto& ts = ekat::TestSession::get();
+
+  int num_elems = ipdf(5,50)(engine);
+  if (ts.params.count("ne")>0) {
+    num_elems = std::stoi(ts.params["ne"]);
+  }
+  int nm1 = 0;
+  int n0  = 1;
+  int np1 = 2;
+
+  HybridVCoord hvcoord;
+  hvcoord.random_init(seed);
+  const auto max_pressure = 1000 + hvcoord.ps0;
+
+  ElementsST<Real> elems_h0, elems_h, elems_ref;
+  ElementsST<DpFadType> elems_dp;
+  elems_h0.init(num_elems,false,true,PhysicalConstants::rearth0,-1,true);
+  elems_h.init(num_elems,false,true,PhysicalConstants::rearth0,-1,true);
+  elems_dp.init(num_elems,false,true,PhysicalConstants::rearth0,-1,true);
+  elems_ref.init(num_elems,false,true,PhysicalConstants::rearth0,-1,true);
+
+  auto& geometry = elems_h0.m_geometry = elems_h.m_geometry = elems_dp.m_geometry = elems_ref.m_geometry;
+  Context::singleton().create_ref(elems_h0.m_geometry);
+  geometry.randomize(seed);
+
+  elems_ref.m_state.randomize(seed,max_pressure,hvcoord.ps0,hvcoord.hybrid_ai0,geometry.m_phis);
+
+  // Create Perturbed constants and Dirk instances
+  using PerturbedConstantsReal = PerturbedConstants<Real>;
+  using PerturbedConstantsFad  = PerturbedConstants<DpFadType>;
+  using DirkReal = DirkFunctorImplST<Real,PerturbedConstantsReal>;
+  using DirkFad  = DirkFunctorImplST<DpFadType,PerturbedConstantsFad>;
+
+  // EquationOfState<PerturbedConstantsReal> eos_real;
+  // EquationOfState<PerturbedConstantsFad>  eos_fad;
+
+  DirkReal dirk_real(num_elems);
+  DirkFad  dirk_dp(num_elems);
+  dirk_real.m_verbose = false;
+  dirk_dp.m_verbose = false;
+  dirk_dp.m_eos.m_constants.perturb.fastAccessDx(0) = 1;
+
+  FunctorsBuffersManager fbm;
+  fbm.request_size(dirk_real.requested_buffer_size());
+  fbm.request_size(dirk_dp.requested_buffer_size());
+  fbm.allocate();
+  dirk_real.init_buffers(fbm);
+  dirk_dp.init_buffers(fbm);
+
+  // Run for different configs and check convergence as perturb->0
+  const std::vector<Real> h_vals = {1e-1, 1e-2, 1e-3, 1e-4, 1e-5, 1e-6, 1e-7, 1e-8};
+  Real dt2 = rpdf(0.1,0.9)(engine);
+  const auto rtol = 1e-4;
+  const auto atol = 1e-6;
+
+  SECTION ("initial_guess") {
+    // Run dirk_dp
+    elems_dp.m_state.import_values(elems_ref.m_state,np1);
+    dirk_dp.run_initial_guess(np1,elems_dp,hvcoord);
+    auto dphi = ekat::scalarize(elems_dp.m_derived.m_divdp_proj);
+
+    // Run dirk_real with no perturbation
+    dirk_real.m_eos.m_constants.perturb = 0;
+    elems_h0.m_state.import_values(elems_ref.m_state,np1);
+    dirk_real.run_initial_guess(np1,elems_h0,hvcoord);
+    auto phi0 = ekat::scalarize(elems_h0.m_derived.m_divdp_proj);
+
+    Kokkos::MDRangePolicy<ExecSpace,Kokkos::Rank<4>> policy({0,0,0,0},{num_elems,np,np,nlev});
+    // Run perturbed dirk_real
+    std::vector<Real> eh;
+    for (auto h : h_vals) {
+      dirk_real.m_eos.m_constants.perturb = h;
+      elems_h.m_state.import_values(elems_ref.m_state,np1);
+      dirk_real.run_initial_guess(np1,elems_h,hvcoord);
+
+      // Compute error on initial guess deriv
+      auto phih = ekat::scalarize(elems_h.m_derived.m_divdp_proj);
+
+      auto linf = KOKKOS_LAMBDA(int ie, int ip, int jp, int ilev, Real& accum) {
+        Real dphi_fd = (phih(ie,ip,jp,ilev) - phi0(ie,ip,jp,ilev)) / h;
+        Real dphi_ex = dphi(ie,ip,jp,ilev).fastAccessDx(0);
+        Real lcl_err = Kokkos::abs(dphi_fd-dphi_ex);
+        if (lcl_err > accum) accum = lcl_err;
+      };
+      Kokkos::parallel_reduce(policy,linf,Kokkos::Max<Real>(eh.emplace_back(0)));
+    }
+    std::cout << std::setprecision(16) << "      h = [" << ekat::join(h_vals,",") << "]\n";
+    std::cout << std::setprecision(16) << "      |dv/dp - FD(dvdp)|_inf = [" << ekat::join(eh,",") << "]\n";
+    const Real min_err = *std::min_element(eh.begin(),eh.end());
+    REQUIRE ((eh[0]<atol or min_err<eh[0]*rtol));
+  }
+
+  SECTION ("run") {
+    const bool bfb_solver = false;
+    Kokkos::MDRangePolicy<ExecSpace,Kokkos::Rank<4>> policy({0,0,0,0},{num_elems,np,np,nlev+1});
+    for (Real alphadt_nm1 : {0.0, 0.3}) {
+      nm1 = alphadt_nm1 == 0.0 ? -1 : 0;
+      printf("-> alphadt_nm1: %f\n", alphadt_nm1);
+      for (Real alphadt_n0 : {0.0, 0.7}) {
+        printf("  -> alphadt_n0: %f\n", alphadt_n0);
+
+        // Run dirk_dp
+        elems_dp.m_state.import_values(elems_ref.m_state,0);
+        elems_dp.m_state.import_values(elems_ref.m_state,1);
+        elems_dp.m_state.import_values(elems_ref.m_state,2);
+        dirk_dp.run(nm1,alphadt_nm1,n0,alphadt_n0,np1,dt2,elems_dp,hvcoord,bfb_solver);
+        auto dphi = ekat::scalarize(elems_dp.m_state.m_phinh_i);
+
+        // Run dirk_real with no perturbation
+        dirk_real.m_eos.m_constants.perturb = 0;
+        elems_h0.m_state.import_values(elems_ref.m_state,0);
+        elems_h0.m_state.import_values(elems_ref.m_state,1);
+        elems_h0.m_state.import_values(elems_ref.m_state,2);
+        dirk_real.run(nm1,alphadt_nm1,n0,alphadt_n0,np1,dt2,elems_h0,hvcoord,bfb_solver);
+        auto phi0 = ekat::scalarize(elems_h0.m_state.m_phinh_i);
+
+        // Run perturbed dirk_real
+        std::vector<Real> eh;
+        for (auto h : h_vals) {
+          dirk_real.m_eos.m_constants.perturb = h;
+          elems_h.m_state.import_values(elems_ref.m_state,0);
+          elems_h.m_state.import_values(elems_ref.m_state,1);
+          elems_h.m_state.import_values(elems_ref.m_state,2);
+          dirk_real.run(nm1,alphadt_nm1,n0,alphadt_n0,np1,dt2,elems_h,hvcoord,bfb_solver);
+          auto phih = ekat::scalarize(elems_h.m_state.m_phinh_i);
+
+          // Compute error on phi(np1)
+          auto linf = KOKKOS_LAMBDA(int ie, int ip, int jp, int ilev, Real& accum) {
+            Real dphi_fd = (phih(ie,np1,ip,jp,ilev) - phi0(ie,np1,ip,jp,ilev)) / h;
+            Real dphi_ex = dphi(ie,np1,ip,jp,ilev).fastAccessDx(0);
+            Real lcl_err = Kokkos::abs(dphi_fd-dphi_ex);
+            if (lcl_err > accum) accum = lcl_err;
+          };
+          Kokkos::parallel_reduce(policy,linf,Kokkos::Max<Real>(eh.emplace_back(0)));
+        }
+        std::cout << std::setprecision(16) << "      h = [" << ekat::join(h_vals,",") << "]\n";
+        std::cout << std::setprecision(16) << "      |dv/dp - FD(dvdp)|_inf = [" << ekat::join(eh,",") << "]\n";
+        const Real min_err = *std::min_element(eh.begin(),eh.end());
+        REQUIRE ((eh[0]<atol or min_err<eh[0]*rtol));
+      }
+    }
+  }
+
+  Context::finalize_singleton();
+}

--- a/components/homme/test_execs/thetal_kokkos_ut/dirk_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/dirk_ut.cpp
@@ -347,13 +347,14 @@ TEST_CASE ("dirk_pieces_testing") {
       d  = dfi::get_ls_slot(ls, 0, 1),
       du = dfi::get_ls_slot(ls, 0, 2);
 
+    PhysicalConstantsProvider constants;
     const auto f1 = KOKKOS_LAMBDA(const dfi::MT& t) {
       KernelVariables kv(t);
       dfi::transpose(kv, nlev, dp3d, dp3dw);
       dfi::transpose(kv, nlev, dphi, dphiw);
       dfi::transpose(kv, nlev, pnh, pnhw);
       kv.team_barrier();
-      dfi::calc_jacobian(kv, dt, dp3dw, dphiw, pnhw, dl, d, du);
+      dfi::calc_jacobian(kv, constants, dt, dp3dw, dphiw, pnhw, dl, d, du);
     };
     parallel_for(d1.m_policy, f1); fence();
 

--- a/components/homme/test_execs/thetal_kokkos_ut/tridiag_sacado_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/tridiag_sacado_ut.cpp
@@ -1,0 +1,116 @@
+#include <catch2/catch.hpp>
+
+#include "Types.hpp"
+#include "utilities/scream_tridiag.hpp"
+
+#include <ekat_string_utils.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <random>
+#include <vector>
+
+namespace Homme {
+
+TEST_CASE ("tridiag_dp_testing")
+{
+  // Setup random number generator
+  std::random_device rd;
+  const unsigned int catchRngSeed = Catch::rngSeed();
+  const unsigned int seed = catchRngSeed==0 ? rd() : catchRngSeed;
+  std::cout << "seed: " << seed << (catchRngSeed==0 ? " (catch rng seed was 0)\n" : "\n");
+
+  using rngAlg = std::mt19937_64;
+  using rpdf = std::uniform_real_distribution<Real>;
+  rngAlg engine(seed);
+
+  // Keep dimensions modest for fast unit tests, but use multiple rhs columns.
+  constexpr int nrow = 16;
+  constexpr int nrhs = 3;
+  const std::vector<Real> h_vals = {1e-2, 1e-4, 1e-6, 1e-8};
+  const Real rtol = 1e-2;
+  const Real atol = 1e-12;
+
+  using View1D = Kokkos::View<Real*, HostMemSpace>;
+  using View2D = Kokkos::View<Real**, HostMemSpace>;
+  using FadView1D = Kokkos::View<DpFadType*, HostMemSpace>;
+  using FadView2D = Kokkos::View<DpFadType**, HostMemSpace>;
+
+  View1D dl0("dl0", nrow), d0("d0", nrow), du0("du0", nrow);
+  View2D rhs0("rhs0", nrow, nrhs), drhs("drhs", nrow, nrhs);
+
+  for (int i = 0; i < nrow; ++i) {
+    dl0(i) = i == 0 ? 0.0 : rpdf(0.05,0.2)(engine);
+    du0(i) = i == nrow-1 ? 0.0 : rpdf(0.05,0.2)(engine);
+    d0(i) = 2.0 + std::abs(dl0(i)) + std::abs(du0(i));
+    for (int j = 0; j < nrhs; ++j) {
+      rhs0(i,j) = rpdf(-1,1)(engine);
+      drhs(i,j) = rpdf(-1,1)(engine);
+    }
+  }
+
+  auto copy_diag = [&](View1D dl, View1D d, View1D du) {
+    for (int i = 0; i < nrow; ++i) {
+      dl(i) = dl0(i);
+      d(i) = d0(i);
+      du(i) = du0(i);
+    }
+  };
+
+  auto solve_real = [&](Real h, View2D x) {
+    View1D dl("dl", nrow), d("d", nrow), du("du", nrow);
+    copy_diag(dl,d,du);
+    for (int i = 0; i < nrow; ++i) {
+      for (int j = 0; j < nrhs; ++j) {
+        x(i,j) = rhs0(i,j) + h*drhs(i,j);
+      }
+    }
+    scream::tridiag::thomas(dl,d,du,x);
+  };
+
+  View2D x0("x0", nrow, nrhs);
+  solve_real(0.0, x0);
+
+  FadView1D dl_fad("dl_fad", nrow), d_fad("d_fad", nrow), du_fad("du_fad", nrow);
+  FadView2D x_fad("x_fad", nrow, nrhs);
+  for (int i = 0; i < nrow; ++i) {
+    dl_fad(i) = dl0(i);
+    d_fad(i) = d0(i);
+    du_fad(i) = du0(i);
+  }
+  DpFadType p_fad = DpFadType(0);
+  p_fad.fastAccessDx(0) = 1.0;
+  for (int i = 0; i < nrow; ++i) {
+    for (int j = 0; j < nrhs; ++j) {
+      x_fad(i,j) = rhs0(i,j) + p_fad*drhs(i,j);
+    }
+  }
+  scream::tridiag::thomas(dl_fad,d_fad,du_fad,x_fad);
+
+  std::vector<Real> eh;
+  for (auto h : h_vals) {
+    View2D xh("xh", nrow, nrhs);
+    solve_real(h, xh);
+    Real linf = 0;
+    for (int i = 0; i < nrow; ++i) {
+      for (int j = 0; j < nrhs; ++j) {
+        const Real dfdp_fd = (xh(i,j) - x0(i,j))/h;
+        const Real dfdp_ad = x_fad(i,j).fastAccessDx(0);
+        linf = std::max(linf, std::abs(dfdp_fd - dfdp_ad));
+      }
+    }
+    eh.emplace_back(linf);
+  }
+
+  std::cout << std::setprecision(16) << "      h = [" << ekat::join(h_vals,",") << "]\n";
+  std::cout << std::setprecision(16) << "      |dx/dp - FD(dxdp)|_inf = [" << ekat::join(eh,",") << "]\n";
+  // Accept if: (a) coarsest-step error is already absolutely tiny, or
+  // (b) refinement decreases the error substantially before roundoff dominates.
+  const Real min_err = *std::min_element(eh.begin(),eh.end());
+  REQUIRE ((eh[0]<atol or min_err<eh[0]*rtol));
+}
+
+} // namespace Homme


### PR DESCRIPTION

- Rely on physics constants perturbation. Namely, perturb gas constant.
- Start testing d(DIRK)/dp by comparing against finite differences
- Add unit test for sacado correctness of tridiag solver too
