### PR TITLE
Make phys const provided methods non-static

### DIFF
--- a/components/homme/src/share/cxx/PhysicalConstants.hpp
+++ b/components/homme/src/share/cxx/PhysicalConstants.hpp
@@ -36,37 +36,38 @@ namespace PhysicalConstants
 // the constants provider, so that we can for instance test sensitivities w.r.t
 // a physics constant. Of course, if a functor uses physics constants and we
 // want to test its sens calculation using the phys constants as param,
-// the functor impl must:
-//  - a) be templated on the constants provider
-//  - b) change PhysicalConstants::xyz to TemplateArg::xyz()
+// the functor impl must use a different instantiation of the constants provider.
+// A possibility is to template on the provider type, and store an instance
+// of the provider. Sensitivity tests can then instantiate the functor with
+// an ad-hoc class that provides a way to perturb some constants
 
 struct PhysicalConstantsProvider {
   // Thermodynamics constants
-  static KOKKOS_FORCEINLINE_FUNCTION
-  constexpr Real Rwater_vapor  () { return PhysicalConstants::Rwater_vapor;  }
-  static KOKKOS_FORCEINLINE_FUNCTION
-  constexpr Real Cpwater_vapor () { return PhysicalConstants::Cpwater_vapor; }
-  static KOKKOS_FORCEINLINE_FUNCTION
-  constexpr Real Rgas          () { return PhysicalConstants::Rgas;          }
-  static KOKKOS_FORCEINLINE_FUNCTION
-  constexpr Real cp            () { return PhysicalConstants::cp;            }
-  static KOKKOS_FORCEINLINE_FUNCTION
-  constexpr Real kappa         () { return PhysicalConstants::kappa;         }
+  KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real Rwater_vapor  () const { return PhysicalConstants::Rwater_vapor;  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real Cpwater_vapor () const { return PhysicalConstants::Cpwater_vapor; }
+  KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real Rgas          () const { return PhysicalConstants::Rgas;          }
+  KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real cp            () const { return PhysicalConstants::cp;            }
+  KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real kappa         () const { return PhysicalConstants::kappa;         }
 
-  static KOKKOS_FORCEINLINE_FUNCTION
-  constexpr Real Tref            () { return PhysicalConstants::Tref;            }
-  static KOKKOS_FORCEINLINE_FUNCTION
-  constexpr Real Tref_lapse_rate () { return PhysicalConstants::Tref_lapse_rate; }
+  KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real Tref            () const { return PhysicalConstants::Tref;            }
+  KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real Tref_lapse_rate () const { return PhysicalConstants::Tref_lapse_rate; }
 
   // Earth constants
-  static KOKKOS_FORCEINLINE_FUNCTION
-  constexpr Real rearth0  () { return PhysicalConstants::rearth0;  }
-  static KOKKOS_FORCEINLINE_FUNCTION
-  constexpr Real rrearth0 () { return PhysicalConstants::rrearth0; }
-  static KOKKOS_FORCEINLINE_FUNCTION
-  constexpr Real g        () { return PhysicalConstants::g;        }
-  static KOKKOS_FORCEINLINE_FUNCTION
-  constexpr Real p0       () { return PhysicalConstants::p0;       }  // [mbar]
+  KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real rearth0  () const { return PhysicalConstants::rearth0;  }
+  KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real rrearth0 () const { return PhysicalConstants::rrearth0; }
+  KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real g        () const { return PhysicalConstants::g;        }
+  KOKKOS_FORCEINLINE_FUNCTION
+  constexpr Real p0       () const { return PhysicalConstants::p0;       }  // [mbar]
 };
 
 } // namespace Homme

--- a/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
@@ -170,6 +170,7 @@ struct DirkFunctorImplST {
     const auto work = m_work;
     const auto tu   = m_tu_ig;
 
+    EquationOfState<> eos;
     const auto toplevel = KOKKOS_LAMBDA (const MT& team) {
       KernelVariables kv(team, tu);
       const auto ie = kv.ie;
@@ -188,9 +189,9 @@ struct DirkFunctorImplST {
         const auto phi_i_c = Homme::subview(phi_i,igp,jgp);
 
         elem_ops.compute_hydrostatic_p(kv, Homme::subview(e_dp3d,ie,np1,igp,jgp), p_i_c, p_c);
-        EquationOfState<>::compute_phi_i(kv, e_phis(ie,igp,jgp),
-                                         Homme::subview(e_vtheta_dp,ie,np1,igp,jgp),
-                                         p_c, phi_i_c);
+        eos.compute_phi_i(kv, e_phis(ie,igp,jgp),
+                          Homme::subview(e_vtheta_dp,ie,np1,igp,jgp),
+                          p_c, phi_i_c);
 
         // Copy phi_i for use in run_newton. Don't need nlevp, since that's
         // always phis.
@@ -230,6 +231,7 @@ struct DirkFunctorImplST {
     const auto hybi = hvcoord.hybrid_bi;
     const auto tu   = m_tu;
 
+    EquationOfState<> eos;
     const auto toplevel = KOKKOS_LAMBDA (const MT& team, int& nerr) {
       KernelVariables kv(team, tu);
       const auto ie = kv.ie;
@@ -281,7 +283,7 @@ struct DirkFunctorImplST {
           dphi(k,i) = phi_np1(k+1,i) - phi_np1(k,i);
         });
         kv.team_barrier();
-        const bool ok = pnh_and_exner_from_eos(kv, hvcoord, vtheta_dp, dp3d,
+        const bool ok = pnh_and_exner_from_eos(kv, hvcoord, eos, vtheta_dp, dp3d,
                                                dphi, pnh, wrk, dpnh_dp_i);
         if ( ! ok) nerr = 1;
         kv.team_barrier();
@@ -319,7 +321,7 @@ struct DirkFunctorImplST {
       // Initial guess for phi_np1.
       if (calc_initial_guess_in_newton_kernel) {
         // Use hydrostatic phi.
-        phi_from_eos(kv, nlev, nvec, hvcoord, subview(e_phis,ie,a,a), vtheta_dp, dp3d, phi_np1);
+        phi_from_eos(kv, eos, nlev, nvec, hvcoord, subview(e_phis,ie,a,a), vtheta_dp, dp3d, phi_np1);
       } else {
         // Copy initial guess from where run_initial_guess stashed it.
         transpose(kv, nlev, subview(e_initial_guess,ie,a,a,a), phi_np1);
@@ -345,7 +347,7 @@ struct DirkFunctorImplST {
       int it = 0;
       ST deltaerr = 0;
       for (; it < maxiter; ++it) { // Newton iteration
-        const bool ok = pnh_and_exner_from_eos(kv, hvcoord, vtheta_dp, dp3d,
+        const bool ok = pnh_and_exner_from_eos(kv, hvcoord, eos, vtheta_dp, dp3d,
                                                dphi, pnh, wrk, dpnh_dp_i);
         if ( ! ok) nerr = 1;
         kv.team_barrier();
@@ -399,7 +401,8 @@ struct DirkFunctorImplST {
     };
 
     int nerr;
-    Kokkos::parallel_reduce(m_policy, toplevel, nerr);
+    auto policy = m_policy;
+    Kokkos::parallel_reduce(policy, toplevel, nerr);
     if (nerr > 0) {
       const int nt[] = {nm1, n0, np1};
       const char* ntname[] = {"nm1", "n0", "np1"};
@@ -557,9 +560,10 @@ struct DirkFunctorImplST {
   }
 
   template <typename R, typename W, typename Wi>
-  KOKKOS_INLINE_FUNCTION
-  static bool pnh_and_exner_from_eos (
+  KOKKOS_INLINE_FUNCTION static
+  bool pnh_and_exner_from_eos (
     const KernelVariables& kv, const HybridVCoord& hvcoord,
+    const EquationOfState<>& eos,
     // All arrays are in DIRK format.
     const R& vtheta_dp, const R& dp3d, const R& dphi,
     // exner is workspace. dpnh_dp_i(nlevp,:) is not computed.
@@ -575,10 +579,12 @@ struct DirkFunctorImplST {
     // Compute pnh(1:nlev,:). pnh(nlevp,:) is not needed.
     const auto f1 = [&] (const int k) {
       const auto g = [&] (const int i) {
-        for (int s = 0; s < ns; ++s)
-          if (vtheta_dp(k,i)[s] < 0 || dphi(k,i)[s] > 0) ok = false;
-        EquationOfState<>::compute_pnh_and_exner(
-          vtheta_dp(k,i), dphi(k,i), pnh(k,i), exner(k,i));
+        for (int s = 0; s < ns; ++s) {
+          if (vtheta_dp(k,i)[s] < 0 || dphi(k,i)[s] > 0)
+            ok = false;
+        }
+
+        eos.compute_pnh_and_exner(vtheta_dp(k,i), dphi(k,i), pnh(k,i), exner(k,i));
       };
       parallel_for(pv, g);
     };
@@ -617,7 +623,8 @@ struct DirkFunctorImplST {
   // parallelization.
   template <typename Rphis, typename R, typename W>
   KOKKOS_INLINE_FUNCTION static void
-  phi_from_eos (const KernelVariables& kv, const int nlev, const int nvec,
+  phi_from_eos (const KernelVariables& kv, const EquationOfState<>& eos,
+                const int nlev, const int nvec,
                 const HybridVCoord& hvcoord, const Rphis& phis, const R& vtheta_dp, const R& dp,
                 // phi_i on output
                 const W& wrk)
@@ -633,7 +640,7 @@ struct DirkFunctorImplST {
     kv.team_barrier();
     // Do most of the flops.
     loop_ki(kv, nlev, nvec, [&] (int k, int i) {
-      wrk(k,i) = EquationOfState<>::compute_dphi(vtheta_dp(k,i), wrk(k,i)); // dphi
+      wrk(k,i) = eos.compute_dphi(vtheta_dp(k,i), wrk(k,i)); // dphi
     });
     kv.team_barrier();
     // Scan to compute phi_i.

--- a/components/homme/src/theta-l_kokkos/cxx/EquationOfState.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/EquationOfState.hpp
@@ -33,24 +33,24 @@ public:
   // On input, pe is pressure; on output, the Exner function.
   template<typename ST>
   KOKKOS_INLINE_FUNCTION
-  static void pressure_to_exner (ST& pe) {
-    pe /= Constants::p0();
+  void pressure_to_exner (ST& pe) const {
+    pe /= m_constants.p0();
 #ifdef HOMMEXX_BFB_TESTING
-    pe = bfb_pow(pe,Constants::kappa());
+    pe = bfb_pow(pe,m_constants.kappa());
 #else
-    pe = pow(pe,Constants::kappa());
+    pe = pow(pe,m_constants.kappa());
 #endif
   }
 
   // On input, pe is pressure; on output, the reciprocal of the Exner function.
   template<typename ST>
   KOKKOS_INLINE_FUNCTION
-  static void pressure_to_recip_exner (ST& pe) {
-    pe = Constants::p0() / pe;
+  void pressure_to_recip_exner (ST& pe) const {
+    pe = m_constants.p0() / pe;
 #ifdef HOMMEXX_BFB_TESTING
-    pe = bfb_pow(pe,Constants::kappa());
+    pe = bfb_pow(pe,m_constants.kappa());
 #else
-    pe = pow(pe,Constants::kappa());
+    pe = pow(pe,m_constants.kappa());
 #endif
   }
 
@@ -103,16 +103,16 @@ public:
   //  3) exner = pnh/p_over_exner
   template<typename ST>
   KOKKOS_INLINE_FUNCTION
-  static void compute_pnh_and_exner (const ST& vtheta_dp, const ST& dphi,
-                                     ST& pnh, ST& exner) {
-    exner = (-Constants::Rgas())*vtheta_dp / dphi;
-    pnh = exner/Constants::p0();
+  void compute_pnh_and_exner (const ST& vtheta_dp, const ST& dphi,
+                                     ST& pnh, ST& exner) const {
+    exner = (-m_constants.Rgas())*vtheta_dp / dphi;
+    pnh = exner/m_constants.p0();
 #ifndef HOMMEXX_BFB_TESTING
-    pnh = pow(pnh,1.0/(1.0-Constants::kappa()));
+    pnh = pow(pnh,1.0/(1.0-m_constants.kappa()));
 #else
-    pnh = bfb_pow(pnh,1.0/(1.0-Constants::kappa()));
+    pnh = bfb_pow(pnh,1.0/(1.0-m_constants.kappa()));
 #endif
-    pnh *= Constants::p0();
+    pnh *= m_constants.p0();
     exner = pnh/exner;    
   }
 
@@ -164,12 +164,12 @@ public:
   //       p is computed using dp from pnh, this will be the discrete inverse of
   //       the compute_pnh_and_exner method.
   template<typename VThetaProvider, typename PProvider, typename ST>
-  KOKKOS_INLINE_FUNCTION static
+  KOKKOS_INLINE_FUNCTION
   void compute_phi_i (const KernelVariables& kv,
                       const ExecViewUnmanaged<const Real [NP][NP]>& phis,
                       const VThetaProvider& vtheta_dp,
                       const PProvider&      p,
-                      const ExecViewUnmanaged<PackType<ST>[NP][NP][NUM_LEV_P]>& phi_i) {
+                      const ExecViewUnmanaged<PackType<ST>[NP][NP][NUM_LEV_P]>& phi_i) const {
     Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team,NP*NP),
                          [&](const int idx) {
       const int igp = idx / NP;
@@ -184,11 +184,11 @@ public:
   // VThetaProvider can be either a 1d view or a lambda,
   // as long as vtheta_dp(ilev) returns vtheta_dp at pack ilev
   template<typename VThetaProvider, typename PProvider, typename ST>
-  KOKKOS_INLINE_FUNCTION static
+  KOKKOS_INLINE_FUNCTION
   void compute_phi_i (const KernelVariables& kv, const Real phis,
                       const VThetaProvider& vtheta_dp,
                       const PProvider& p,
-                      const ExecViewUnmanaged<PackType<ST> [NUM_LEV_P]>& phi_i)
+                      const ExecViewUnmanaged<PackType<ST> [NUM_LEV_P]>& phi_i) const
   {
     // Init phi on surface with phis
     phi_i(LAST_INT_PACK)[LAST_INT_PACK_END] = phis;
@@ -202,11 +202,11 @@ public:
   }
 
   template<typename ST>
-  KOKKOS_INLINE_FUNCTION static
-  ST compute_dphi (const ST& vtheta_dp, const ST& p) {
-    const auto p0    = Constants::p0();
-    const auto kappa = Constants::kappa();
-    const auto Rgas  = Constants::Rgas();
+  KOKKOS_INLINE_FUNCTION
+  ST compute_dphi (const ST& vtheta_dp, const ST& p) const {
+    const auto p0    = m_constants.p0();
+    const auto kappa = m_constants.kappa();
+    const auto Rgas  = m_constants.Rgas();
 #ifdef HOMMEXX_BFB_TESTING
     return (Rgas*vtheta_dp * bfb_pow(p/p0,kappa-1)) / p0;
 #else
@@ -250,7 +250,7 @@ public:
     phi_i(LAST_INT_PACK)[LAST_INT_PACK_END] = phis;
 
     // Use ColumnOps to do the scan sum
-    const auto Rgas  = Constants::Rgas();
+    const auto Rgas  = m_constants.Rgas();
     auto integrand_provider = [&](const int ilev) {
       return Rgas*vtheta_dp(ilev)*exner(ilev)/p(ilev);
     };
@@ -262,6 +262,8 @@ public:
 
   bool            m_theta_hydrostatic_mode;
   HybridVCoord    m_hvcoord;
+
+  Constants       m_constants;
 };
 
 } // namespace Homme

--- a/components/homme/test_execs/thetal_kokkos_ut/dirk_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/dirk_ut.cpp
@@ -478,13 +478,14 @@ TEST_CASE ("dirk_pieces_testing") {
       exnerw = dfi::get_work_slot(w, 0, 4),
       dpnh_dp_iw = dfi::get_work_slot(w, 0, 5);
 
+    EquationOfState<> eos;
     const auto f = KOKKOS_LAMBDA(const dfi::MT& t) {
       KernelVariables kv(t);
       dfi::transpose(kv, nlev, vtheta_dp, vtheta_dpw);
       dfi::transpose(kv, nlev, dp3d, dp3dw);
       dfi::transpose(kv, nlev, dphi, dphiw);
       kv.team_barrier();
-      dfi::pnh_and_exner_from_eos(kv, hvcoord, vtheta_dpw, dp3dw, dphiw,
+      dfi::pnh_and_exner_from_eos(kv, hvcoord, eos, vtheta_dpw, dp3dw, dphiw,
                                   pnhw, exnerw, dpnh_dp_iw);
     };
     parallel_for(d1.m_policy, f); fence();
@@ -739,6 +740,7 @@ TEST_CASE ("dirk_toplevel_testing") {
       const auto e_dp3d = e.m_state.m_dp3d;
       const auto e_phinh_i = e.m_state.m_phinh_i;
       const auto w = d.m_work;
+      EquationOfState<> eos;
       const auto f = KOKKOS_LAMBDA(const dfi::MT& t) {
         KernelVariables kv(t);
         const auto ie = kv.ie;
@@ -750,7 +752,7 @@ TEST_CASE ("dirk_toplevel_testing") {
         dfi::transpose(kv, nlev, subview(e_vtheta_dp,ie,np1,a,a,a), vtheta_dp);
         dfi::transpose(kv, nlev, subview(e_dp3d,ie,np1,a,a,a), dp3d);
         kv.team_barrier();
-        dfi::phi_from_eos(kv, nlev, nvec, hvcoord, subview(e_phis,ie,a,a),
+        dfi::phi_from_eos(kv, eos, nlev, nvec, hvcoord, subview(e_phis,ie,a,a),
                           vtheta_dp, dp3d, phi_np1);
         kv.team_barrier();
         dfi::transpose(kv, nlev, phi_np1, subview(e_phinh_i,ie,np1,a,a,a));

--- a/components/homme/test_execs/thetal_kokkos_ut/eos_sacado_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/eos_sacado_ut.cpp
@@ -21,26 +21,20 @@ namespace PC = PhysicalConstants;
 // A constants provider that perturbs Rgas by a factor (1+perturb).
 // kappa = Rgas/cp is also perturbed as a result.
 // p0 and cp are left unchanged.
-// The perturbation is a static member so it works inside KOKKOS_INLINE_FUNCTION.
+// The perturbation is stored per instance and used by the inline accessors below
 template<typename ST>
-struct PerturbedConstants {
+struct PerturbedConstants : public PhysicalConstantsProvider
+{
+  using PCP = PhysicalConstantsProvider;
 
-  PerturbedConstants() { perturb = ST(0); }
+  PerturbedConstants() = default;
 
-  static ST perturb;
+  ST perturb = 0;
 
-  // Only decl the ones used in EOS
-  static KOKKOS_FORCEINLINE_FUNCTION ST             Rgas  () { return (1+perturb)*PC::Rgas; }
-  static KOKKOS_FORCEINLINE_FUNCTION constexpr Real cp    () { return PC::cp;           }
-  static KOKKOS_FORCEINLINE_FUNCTION ST             kappa () { return Rgas() / cp();    }
-  static KOKKOS_FORCEINLINE_FUNCTION constexpr Real p0    () { return PC::p0;           }  // [mbar]
+  // Only decl the ones we want to change from PCP
+  KOKKOS_FORCEINLINE_FUNCTION ST Rgas  () const { return (1+perturb)*PCP::Rgas(); }
+  KOKKOS_FORCEINLINE_FUNCTION ST kappa () const { return Rgas() / cp();           }
 };
-
-template<typename ST>
-ST PerturbedConstants<ST>::perturb; // Must instantiate static member vars
-
-template<typename Provider>
-using EOS = EquationOfState<Provider>;
 
 // Helper: compute FAD derivative and value for a scalar EOS function,
 // and compare against finite differences as the perturbation h is refined.
@@ -52,7 +46,6 @@ bool check_fad_vs_fd (Func&& run,
                       const char* name)
 {
   // baseline: run with perturb=0
-  PerturbedConstants<Real>::perturb = 0.0;
   const Real f0 = run(0.0);
 
   // Check FAD value matches the baseline
@@ -99,33 +92,29 @@ TEST_CASE("eos_dp_check") {
   hvcoord.random_init(seed);
 
   using FadT = SFadN<Real,1>;
-
-  // Seed the FAD perturbation: perturb has value 0, derivative 1.
-  // The constructor call initialises the static perturb member to ST(0).
-  (void)PerturbedConstants<FadT>{};
-  PerturbedConstants<FadT>::perturb.fastAccessDx(0) = 1.0;
-
-  // Real provider: constructor initialises static perturb to 0.
-  (void)PerturbedConstants<Real>{};
+  using EOSFad  = EquationOfState<PerturbedConstants<FadT>>;
+  using EOSReal = EquationOfState<PerturbedConstants<Real>>;
 
   // Step sizes for finite differences: from coarse to fine to probe convergence
   const std::vector<Real> h_vals = {1e-2, 1e-4, 1e-6, 1e-8};
 
+  EOSFad eos_fad;
+  eos_fad.m_constants.perturb.fastAccessDx(0) = 1;
+  EOSReal eos_real;
   SECTION ("pressure_to_exner") {
     RPDF pdf(10, 1000);
     const Real p0 = pdf(engine);
 
     // Run EOS with Fad type to get FAD derivative
     FadT p_sfad = p0;
-    EOS<PerturbedConstants<FadT>>::pressure_to_exner(p_sfad);
+    eos_fad.pressure_to_exner(p_sfad);
     const Real fad_val   = p_sfad.val();
     const Real fad_deriv = p_sfad.fastAccessDx(0);
 
     auto run = [&](Real h) {
-      PerturbedConstants<Real>::perturb = h;
+      eos_real.m_constants.perturb = h;
       Real p = p0;
-      EOS<PerturbedConstants<Real>>::pressure_to_exner(p);
-      PerturbedConstants<Real>::perturb = 0.0;
+      eos_real.pressure_to_exner(p);
       return p;
     };
 
@@ -137,15 +126,14 @@ TEST_CASE("eos_dp_check") {
     const Real p0 = pdf(engine);
 
     FadT p_sfad = p0;
-    EOS<PerturbedConstants<FadT>>::pressure_to_recip_exner(p_sfad);
+    eos_fad.pressure_to_recip_exner(p_sfad);
     const Real fad_val   = p_sfad.val();
     const Real fad_deriv = p_sfad.fastAccessDx(0);
 
     auto run = [&](Real h) {
-      PerturbedConstants<Real>::perturb = h;
+      eos_real.m_constants.perturb = h;
       Real p = p0;
-      EOS<PerturbedConstants<Real>>::pressure_to_recip_exner(p);
-      PerturbedConstants<Real>::perturb = 0.0;
+      eos_real.pressure_to_recip_exner(p);
       return p;
     };
 
@@ -160,14 +148,13 @@ TEST_CASE("eos_dp_check") {
     // FAD version: inputs are plain (no seed), only constants carry the Fad derivative
     const FadT vtheta_dp_fad = vtheta_dp;
     const FadT p_fad         = p_in;
-    const FadT dphi_sfad     = EOS<PerturbedConstants<FadT>>::compute_dphi(vtheta_dp_fad, p_fad);
+    const FadT dphi_sfad     = eos_fad.compute_dphi(vtheta_dp_fad, p_fad);
     const Real fad_val   = dphi_sfad.val();
     const Real fad_deriv = dphi_sfad.fastAccessDx(0);
 
     auto run = [&](Real h) {
-      PerturbedConstants<Real>::perturb = h;
-      Real dphi = EOS<PerturbedConstants<Real>>::compute_dphi(vtheta_dp, p_in);
-      PerturbedConstants<Real>::perturb = 0.0;
+      eos_real.m_constants.perturb = h;
+      Real dphi = eos_real.compute_dphi(vtheta_dp, p_in);
       return dphi;
     };
 
@@ -187,16 +174,15 @@ TEST_CASE("eos_dp_check") {
     const FadT vtheta_dp_fad = vtheta_dp;
     const FadT dphi_fad      = dphi;
     FadT pnh_fad, exner_fad;
-    EOS<PerturbedConstants<FadT>>::compute_pnh_and_exner(vtheta_dp_fad, dphi_fad, pnh_fad, exner_fad);
+    eos_fad.compute_pnh_and_exner(vtheta_dp_fad, dphi_fad, pnh_fad, exner_fad);
     const Real fad_pnh_val    = pnh_fad.val();
     const Real fad_exner_val  = exner_fad.val();
     const Real fad_dpnh_deps  = pnh_fad.fastAccessDx(0);
     const Real fad_dexner_deps = exner_fad.fastAccessDx(0);
 
     // Baseline Real values
-    PerturbedConstants<Real>::perturb = 0.0;
     Real pnh_0 = 0, exner_0 = 0;
-    EOS<PerturbedConstants<Real>>::compute_pnh_and_exner(vtheta_dp, dphi, pnh_0, exner_0);
+    eos_real.compute_pnh_and_exner(vtheta_dp, dphi, pnh_0, exner_0);
 
     REQUIRE(std::abs(fad_pnh_val - pnh_0)   < 1e-14 * std::abs(pnh_0)   + 1e-14);
     REQUIRE(std::abs(fad_exner_val - exner_0) < 1e-14 * std::abs(exner_0) + 1e-14);
@@ -204,10 +190,9 @@ TEST_CASE("eos_dp_check") {
     // Finite difference for pnh
     {
       auto run_pnh = [&](Real h) {
-        PerturbedConstants<Real>::perturb = h;
+        eos_real.m_constants.perturb = h;
         Real pnh_h = 0, exner_h = 0;
-        EOS<PerturbedConstants<Real>>::compute_pnh_and_exner(vtheta_dp, dphi, pnh_h, exner_h);
-        PerturbedConstants<Real>::perturb = 0.0;
+        eos_real.compute_pnh_and_exner(vtheta_dp, dphi, pnh_h, exner_h);
         return pnh_h;
       };
       REQUIRE(check_fad_vs_fd(run_pnh, fad_pnh_val, fad_dpnh_deps, h_vals, "compute_pnh_and_exner::pnh"));
@@ -216,10 +201,9 @@ TEST_CASE("eos_dp_check") {
     // Finite difference for exner
     {
       auto run_exner = [&](Real h) {
-        PerturbedConstants<Real>::perturb = h;
+        eos_real.m_constants.perturb = h;
         Real pnh_h = 0, exner_h = 0;
-        EOS<PerturbedConstants<Real>>::compute_pnh_and_exner(vtheta_dp, dphi, pnh_h, exner_h);
-        PerturbedConstants<Real>::perturb = 0.0;
+        eos_real.compute_pnh_and_exner(vtheta_dp, dphi, pnh_h, exner_h);
         return exner_h;
       };
       REQUIRE(check_fad_vs_fd(run_exner, fad_exner_val, fad_dexner_deps, h_vals, "compute_pnh_and_exner::exner"));


### PR DESCRIPTION
This forces EOS to store a Constants instance, which means no static methods. In turn, this forces DIRK to use an instance of EOS rather than call static methods.

This is necessary in order to use other instances for Constants in EOS that allow for a tunable perturbation, as the perturbation cannot be static in order to be visible on device.