### PR TITLE
Add lightweight state storage struct

### DIFF
--- a/components/homme/src/share/cxx/utilities/TestUtils.hpp
+++ b/components/homme/src/share/cxx/utilities/TestUtils.hpp
@@ -88,6 +88,82 @@ inline Real compare_answers(Real target, ScalarValue computed,
 }
 #endif
 
+// If last_extent=-1, views last extent must match. Otherwise we compare
+// entries (along last dim) only up to the provided extent.
+template<typename V1, typename V2>
+std::enable_if_t<Kokkos::is_view_v<V1> and Kokkos::is_view_v<V2>, bool>
+views_are_equal(const V1& v1, const V2& v2, int last_extent = 0)
+{
+  if constexpr (v1.rank!=v2.rank)
+    return false;
+
+  constexpr int N = v1.rank;
+  for (int i=0; i<N-1; ++i)
+    if (v1.extent(i)!=v2.extent(i))
+      return false;
+
+  if (last_extent>0) {
+    /// If views are smaller than provided extent, something is off
+    if (v1.extent(N-1)<last_extent or v2.extent(N-1)<last_extent)
+      return false;
+  } else {
+    if (v1.extent(N-1)!=v2.extent(N-1))
+    return false;
+  }
+
+  auto v1h = Kokkos::create_mirror_view(v1);
+  auto v2h = Kokkos::create_mirror_view(v2);
+  Kokkos::deep_copy(v1h,v1);
+  Kokkos::deep_copy(v2h,v2);
+
+  if constexpr (N==0) {
+    return v1h()==v2h();
+  } else if constexpr(N==1) {
+    for (int i=0; i<last_extent; ++i)
+      if (v1h(i)!=v2h(i))
+        return false;
+  } else if constexpr(N==2) {
+    for (int i=0; i<v1.extent(0); ++i)
+      for (int j=0; j<last_extent; ++j)
+        if (v1h(i,j)!=v2h(i,j))
+          return false;
+  } else if constexpr(N==3) {
+    for (int i=0; i<v1.extent(0); ++i)
+      for (int j=0; j<v1.extent(1); ++j)
+        for (int k=0; k<last_extent; ++k)
+          if (v1h(i,j,k)!=v2h(i,j,k))
+            return false;
+  } else if constexpr(N==4) {
+    for (int i=0; i<v1.extent(0); ++i)
+      for (int j=0; j<v1.extent(1); ++j)
+        for (int k=0; k<v1.extent(2); ++k)
+          for (int l=0; l<last_extent; ++l)
+            if (v1h(i,j,k,l)!=v2h(i,j,k,l))
+              return false;
+  } else if constexpr(N==5) {
+    for (int i=0; i<v1.extent(0); ++i)
+      for (int j=0; j<v1.extent(1); ++j)
+        for (int k=0; k<v1.extent(2); ++k)
+          for (int l=0; l<v1.extent(3); ++l)
+            for (int m=0; m<last_extent; ++m)
+              if (v1h(i,j,k,l,m)!=v2h(i,j,k,l,m))
+                return false;
+  } else if constexpr(N==6) {
+    for (int i=0; i<v1.extent(0); ++i)
+      for (int j=0; j<v1.extent(1); ++j)
+        for (int k=0; k<v1.extent(2); ++k)
+          for (int l=0; l<v1.extent(3); ++l)
+            for (int m=0; m<v1.extent(4); ++m)
+              for (int n=0; n<last_extent; ++n)
+                if (v1h(i,j,k,l,m,n)!=v2h(i,j,k,l,m,n))
+                  return false;
+  } else {
+    throw std::runtime_error("[views_are_equal] Unsupported rank (" + std::to_string(N) + ").\n");
+  }
+
+  return true;
+}
+
 } // namespace Homme
 
 #endif // HOMMEXX_TEST_UTILS_HPP

--- a/components/homme/src/share/cxx/utilities/TestUtils.hpp
+++ b/components/homme/src/share/cxx/utilities/TestUtils.hpp
@@ -41,6 +41,8 @@ template <typename FadType, typename rngAlg, typename PDF>
 void genRandArray(FadType *const x, int length, rngAlg &engine, PDF &&pdf) {
   for (int i = 0; i < length; ++i) {
     x[i] = pdf(engine);
+    for (int k=0; k<x[i].size(); ++k)
+      x[i].fastAccessDx(k) = pdf(engine);
   }
 }
 #endif

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState.cpp
@@ -11,6 +11,17 @@
 
 namespace Homme {
 
+void RefStates::init(const int num_elems) {
+  dp_ref = decltype(dp_ref)("dp_ref",num_elems);
+  phi_i_ref = decltype(phi_i_ref)("phi_i_ref",num_elems);
+  theta_ref = decltype(theta_ref)("theta_ref",num_elems);
+
+  m_num_elems = num_elems;
+
+  m_policy = get_default_team_policy<ExecSpace>(num_elems);
+  m_tu     = TeamUtils<ExecSpace>(m_policy);
+}
+
 // ETI for the commonly used scalar type
 template class ElementsStateST<Real>;
 

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
@@ -38,6 +38,29 @@ private:
   TeamUtils<ExecSpace> m_tu;
 };
 
+struct StateSnapshot {
+  using ST = Real;
+  using PT = PackType<ST>;
+
+  StateSnapshot (int nelem, bool alloc_ps = false)
+   : v ("v",nelem)
+   , vtheta_dp ("vtheta_dp",nelem)
+   , dp3d ("dp3d",nelem)
+   , w_i ("w",nelem)
+   , phinh_i ("phinh",nelem)
+  {
+    if (alloc_ps)
+      ps_v = decltype(ps_v)("ps",nelem);
+  }
+
+  ExecViewManaged<PT * [2][NP][NP][NUM_LEV  ]> v;          // Horizontal velocity
+  ExecViewManaged<PT *    [NP][NP][NUM_LEV  ]> vtheta_dp;  // Virtual potential temperature (mass)
+  ExecViewManaged<PT *    [NP][NP][NUM_LEV  ]> dp3d;       // Delta p on levels
+  ExecViewManaged<PT *    [NP][NP][NUM_LEV_P]> w_i;        // Vertical velocity at interfaces
+  ExecViewManaged<PT *    [NP][NP][NUM_LEV_P]> phinh_i;    // Geopotential used by NH model at interfaces
+  ExecViewManaged<ST *    [NP][NP]           > ps_v;       // Surface pressure
+};
+
 /* Per element data - specific velocity, temperature, pressure, etc. */
 template<typename ST>
 class ElementsStateST {
@@ -86,6 +109,8 @@ public:
   // Copy values from one ElementStateST struct to another. All derivs get set to 0.
   template<typename RST>
   void import_values (const ElementsStateST<RST>& rhs, int tl);
+
+  StateSnapshot export_values (int tl, bool do_ps = false);
 
   // Check ElementsState for NaN or incorrectly signed values. The initial check
   // is fast and on device. If everything is fine, the routine returns

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState_def.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState_def.hpp
@@ -27,17 +27,6 @@
 
 namespace Homme {
 
-void RefStates::init(const int num_elems) {
-  dp_ref = decltype(dp_ref)("dp_ref",num_elems);
-  phi_i_ref = decltype(phi_i_ref)("phi_i_ref",num_elems);
-  theta_ref = decltype(theta_ref)("theta_ref",num_elems);
-
-  m_num_elems = num_elems;
-
-  m_policy = get_default_team_policy<ExecSpace>(num_elems);
-  m_tu     = TeamUtils<ExecSpace>(m_policy);
-}
-
 template<typename ST>
 void ElementsStateST<ST>::init(const int num_elems) {
   m_num_elems = num_elems;

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState_def.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState_def.hpp
@@ -564,6 +564,45 @@ HashType ElementsStateST<ST>::hash (const int tl) const {
   return accum;
 }
 
+template<typename ST>
+StateSnapshot ElementsStateST<ST>::export_values (int tl, bool do_ps)
+{
+  constexpr auto NPL = NUM_PHYSICAL_LEV;
+  StateSnapshot snap(m_num_elems,do_ps);
+
+  auto v   = ekat::scalarize(m_v);
+  auto vth = ekat::scalarize(m_vtheta_dp);
+  auto dp  = ekat::scalarize(m_dp3d);
+  auto w   = ekat::scalarize(m_w_i);
+  auto phi = ekat::scalarize(m_phinh_i);
+  auto ps  = ekat::scalarize(m_ps_v);
+  auto snap_v   = ekat::scalarize(snap.v);
+  auto snap_vth = ekat::scalarize(snap.vtheta_dp);
+  auto snap_dp  = ekat::scalarize(snap.dp3d);
+  auto snap_w   = ekat::scalarize(snap.w_i);
+  auto snap_phi = ekat::scalarize(snap.phinh_i);
+  auto snap_ps  = ekat::scalarize(snap.ps_v);
+  auto copy = KOKKOS_LAMBDA (int ie, int ip, int jp, int k) {
+    snap_v  (ie,0,ip,jp,k) = ADValue(v  (ie,tl,0,ip,jp,k));
+    snap_v  (ie,1,ip,jp,k) = ADValue(v  (ie,tl,1,ip,jp,k));
+    snap_vth(ie,  ip,jp,k) = ADValue(vth(ie,tl  ,ip,jp,k));
+    snap_dp (ie,  ip,jp,k) = ADValue(dp (ie,tl  ,ip,jp,k));
+    snap_w  (ie,  ip,jp,k) = ADValue(w  (ie,tl  ,ip,jp,k));
+    snap_phi(ie,  ip,jp,k) = ADValue(phi(ie,tl  ,ip,jp,k));
+    if (do_ps) {
+      snap_ps(ie,ip,jp) = ADValue(ps(ie,tl,ip,jp));
+    }
+    if (k==NPL-1) {
+      snap_w  (ie,ip,jp,NPL) = ADValue(w  (ie,tl,ip,jp,NPL));
+      snap_phi(ie,ip,jp,NPL) = ADValue(phi(ie,tl,ip,jp,NPL));
+    }
+  };
+
+  Kokkos::MDRangePolicy<ExecSpace,Kokkos::Rank<4>> policy({0,0,0,0},{m_num_elems,NP,NP,NUM_PHYSICAL_LEV});
+  Kokkos::parallel_for(policy,copy);
+  return snap;
+}
+
 } // namespace Homme
 
 #endif // HOMME_ELEMENTS_STATE_DEF_HPP

--- a/components/homme/test_execs/thetal_kokkos_ut/CMakeLists.txt
+++ b/components/homme/test_execs/thetal_kokkos_ut/CMakeLists.txt
@@ -367,8 +367,16 @@ if (NOT HOMMEXX_ENABLE_FWD_SENS)
   cxx_unit_test_add_test(gllfvremap_planar_ut gllfvremap_ut ${NUM_CPUS} "hommexx -planar")
 endif()
 
+include (EkatCreateUnitTest)
+# State generic tests
+EkatCreateUnitTest (state_ut
+  state_ut.cpp
+  COMPILER_CXX_DEFS
+  LIBS thetal_kokkos_ut_lib
+  LABELS AMDIS
+)
+
 if (HOMMEXX_ENABLE_FAD_TYPES)
-  include (EkatCreateUnitTest)
 
   # Caar sacado derivatives tests
   EkatCreateUnitTest (caar_sacado_ut

--- a/components/homme/test_execs/thetal_kokkos_ut/state_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/state_ut.cpp
@@ -1,0 +1,82 @@
+#include <catch2/catch.hpp>
+
+#include "ElementsState.hpp"
+#include "ElementsState_def.hpp"
+
+#include "Types.hpp"
+
+#include "utilities/TestUtils.hpp"
+
+#include <ekat_pack_kokkos.hpp>
+
+#include <iostream>
+#include <random>
+
+using namespace Homme;
+
+TEST_CASE("state_tests")
+{
+  using rngAlg = std::mt19937_64;
+  using rpdf = std::uniform_real_distribution<Real>;
+  using ipdf = std::uniform_int_distribution<int>;
+
+  std::random_device rd;
+  const unsigned int catchRngSeed = Catch::rngSeed();
+  static unsigned int seed;
+  static bool printed = false;
+  if (not printed) {
+    seed = catchRngSeed==0 ? rd() : catchRngSeed;
+    std::cout << "seed: " << seed << (catchRngSeed==0 ? " (catch rng seed was 0)\n" : "\n");
+  }
+  rngAlg engine(seed);
+
+  constexpr int num_elems = 4;
+  constexpr auto A = Kokkos::ALL();
+
+  SECTION ("export") {
+    ElementsStateST<Real> state;
+    state.init(num_elems);
+    state.randomize(seed);
+
+    auto slice0 = state.export_values(0,false);
+    auto slice1 = state.export_values(1,true);
+
+    REQUIRE (slice0.ps_v.data()==nullptr);
+    REQUIRE (slice1.ps_v.data()!=nullptr);
+
+    REQUIRE (slice0.v.data()!=state.m_v.data());
+    REQUIRE (slice0.v.extent(0)==num_elems);
+
+    REQUIRE (views_are_equal(ekat::scalarize(slice0.v),Kokkos::subview(ekat::scalarize(state.m_v),A,0,A,A,A,A),NUM_PHYSICAL_LEV));
+    REQUIRE (views_are_equal(ekat::scalarize(slice1.ps_v),Kokkos::subview(ekat::scalarize(state.m_ps_v),A,0,A,A)));
+
+    // Make sure we are not getting false positives
+    REQUIRE_FALSE(views_are_equal(ekat::scalarize(slice0.vtheta_dp),ekat::scalarize(slice0.dp3d),NUM_PHYSICAL_LEV));
+  }
+
+#ifdef HOMMEXX_ENABLE_FAD_TYPES
+  SECTION ("import_from_deriv") {
+    using FadT = SFadN<Real,2>;
+    ElementsStateST<Real> state_real;
+    state_real.init(num_elems);
+
+    ElementsStateST<FadT> state_fad;
+    state_fad.init(num_elems);
+    
+    int tl =2;
+    int ider = 1;
+    state_real.import_values_from_deriv (state_fad,tl,ider);
+    auto vrh = Kokkos::create_mirror_view(ekat::scalarize(state_real.m_v));
+    auto vfh = Kokkos::create_mirror_view(ekat::scalarize(state_fad.m_v));
+    Kokkos::deep_copy(vrh,ekat::scalarize(state_real.m_v));
+    Kokkos::deep_copy(vfh,ekat::scalarize(state_fad.m_v));
+    for (int ie=0; ie<num_elems; ++ie)
+      for (int ip=0; ip<NP; ++ip)
+        for (int jp=0; jp<NP; ++jp)
+          for (int k=0; k<NUM_PHYSICAL_LEV; ++k) {
+            REQUIRE (vrh(ie,tl,0,ip,jp,k)==vfh(ie,tl,0,ip,jp,k).fastAccessDx(ider));
+            REQUIRE (vrh(ie,tl,1,ip,jp,k)==vfh(ie,tl,1,ip,jp,k).fastAccessDx(ider));
+          }
+  }
+#endif
+}


### PR DESCRIPTION
This struct holds a snapshot of the state, without the time levels dimension. It is meant to be used when we need to store snapshots of the state during forward solve inside an adjoint sensitivity loop.