### PR TITLE
Change signature of Jacobian applicaiton methods

### DIFF
--- a/components/homme/src/theta-l_kokkos/CMakeLists.txt
+++ b/components/homme/src/theta-l_kokkos/CMakeLists.txt
@@ -144,6 +144,7 @@ MACRO(THETAL_KOKKOS_SETUP)
     ${TARGET_DIR}/cxx/LimiterFunctor.hpp
     ${TARGET_DIR}/cxx/cxx_f90_interface_theta.cpp
     ${TARGET_DIR}/cxx/prim_advance_exp.cpp
+    ${TARGET_DIR}/cxx/StateSnapshot.cpp
     ${SRC_SHARE_DIR}/cxx/CaarFunctor.cpp
     ${SRC_SHARE_DIR}/cxx/Elements.cpp
     ${SRC_SHARE_DIR}/cxx/ElementsDerivedState.cpp

--- a/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
@@ -472,11 +472,11 @@ struct CaarFunctorImplST {
 
   template<typename MyST = ST>
   std::enable_if_t<not std::is_same_v<MyST,DxFadTypeCaar>>
-  run_JV (const RKStageData& data, ElementsStateST<Real>& adj_state) = delete;
+  run_JV (const RKStageData& data, const StateSnapshot& x, StateSnapshot& y) = delete;
 
   template<typename MyST = ST>
   std::enable_if_t<std::is_same_v<MyST,DxFadTypeCaar>>
-  run_JV (const RKStageData& data, ElementsStateST<Real>& adj_state)
+  run_JV (const RKStageData& data, const StateSnapshot& x, StateSnapshot& y)
   {
     constexpr int stencil_sz = 16;
 
@@ -497,29 +497,35 @@ struct CaarFunctorImplST {
     auto dphidx_v = ekat::scalarize(m_state.m_phinh_i);
     auto dwdx_v = ekat::scalarize(m_state.m_w_i);
 
-    // Compute dxnew/dp = dxnew/dxold * dxold/dp
-    int n0 = data.n0;
+    // Compute Y = dxnew/dxold * X
     int np1 = data.np1;
 
-    auto l_V = ekat::scalarize(adj_state.m_v);
-    auto l_vth = ekat::scalarize(adj_state.m_vtheta_dp);
-    auto l_dp = ekat::scalarize(adj_state.m_dp3d);
-    auto l_phi = ekat::scalarize(adj_state.m_phinh_i);
-    auto l_w = ekat::scalarize(adj_state.m_w_i);
-    
+    auto x_V = ekat::scalarize(x.v);
+    auto x_vth = ekat::scalarize(x.vtheta_dp);
+    auto x_dp = ekat::scalarize(x.dp3d);
+    auto x_phi = ekat::scalarize(x.phinh_i);
+    auto x_w = ekat::scalarize(x.w_i);
+
+    auto y_V = ekat::scalarize(y.v);
+    auto y_vth = ekat::scalarize(y.vtheta_dp);
+    auto y_dp = ekat::scalarize(y.dp3d);
+    auto y_phi = ekat::scalarize(y.phinh_i);
+    auto y_w = ekat::scalarize(y.w_i);
+
     constexpr int last_mid = NUM_PHYSICAL_LEV-1;
     auto prod_rule_mid = KOKKOS_LAMBDA (const int ie, const int ipt, const int jpt, const int k) {
-      const auto& l_u_old   = Homme::subview(l_V,ie,n0,0);
-      const auto& l_v_old   = Homme::subview(l_V,ie,n0,1);
-      const auto& l_vth_old = Homme::subview(l_vth,ie,n0);
-      const auto& l_dp_old  = Homme::subview(l_dp,ie,n0);
-      const auto& l_phi_old = Homme::subview(l_phi,ie,n0);
-      const auto& l_w_old   = Homme::subview(l_w,ie,n0);
 
-      auto& l_u_new   = l_V(ie,np1,0,ipt,jpt,k);
-      auto& l_v_new   = l_V(ie,np1,1,ipt,jpt,k);
-      auto& l_vth_new = l_vth(ie,np1,ipt,jpt,k);
-      auto& l_dp_new  = l_dp(ie,np1,ipt,jpt,k);
+      const auto& x_u_ie   = Homme::subview(x_V,ie,0);
+      const auto& x_v_ie   = Homme::subview(x_V,ie,1);
+      const auto& x_vth_ie = Homme::subview(x_vth,ie);
+      const auto& x_dp_ie  = Homme::subview(x_dp,ie);
+      const auto& x_phi_ie = Homme::subview(x_phi,ie);
+      const auto& x_w_ie   = Homme::subview(x_w,ie);
+
+      auto& y_u_val   = y_V(ie,0,ipt,jpt,k);
+      auto& y_v_val   = y_V(ie,1,ipt,jpt,k);
+      auto& y_vth_val = y_vth(ie,ipt,jpt,k);
+      auto& y_dp_val  = y_dp(ie,ipt,jpt,k);
 
       // Jacobians
       const auto& Ju   = dvdx_v(ie,np1,0,ipt,jpt,k).dx();
@@ -529,10 +535,10 @@ struct CaarFunctorImplST {
       const auto& Jphi = dphidx_v(ie,np1,ipt,jpt,k).dx();
       const auto& Jw   = dwdx_v(ie,np1,ipt,jpt,k).dx();
 
-      l_u_new = 0;
-      l_v_new = 0;
-      l_dp_new = 0;
-      l_vth_new = 0;
+      y_u_val = 0;
+      y_v_val = 0;
+      y_dp_val = 0;
+      y_vth_val = 0;
 
       // offsets of each var in the deriv vector
       int u_prev    = offset_u   + (k-1) % 2;
@@ -562,54 +568,54 @@ struct CaarFunctorImplST {
           auto pt_Jdp  = Jdp  + pt_offset;
 
           // Dependencies on k quantities
-          l_u_new += pt_Ju[u_curr]   * l_u_old  (mpt,npt,k)  // du(k)/du(k)
-                   + pt_Ju[v_curr]   * l_v_old  (mpt,npt,k)  // du(k)/dv(k)
-                   + pt_Ju[vth_curr] * l_vth_old(mpt,npt,k)  // du(k)/dvth(k)
-                   + pt_Ju[dp_curr]  * l_dp_old (mpt,npt,k)  // du(k)/ddp(k)
-                   + pt_Ju[phi_curr] * l_phi_old(mpt,npt,k)  // du(k)/dphi(k)
-                   + pt_Ju[w_curr]   * l_w_old  (mpt,npt,k); // du(k)/dw(k)
+          y_u_val += pt_Ju[u_curr]   * x_u_ie  (mpt,npt,k)  // du(k)/du(k)
+                   + pt_Ju[v_curr]   * x_v_ie  (mpt,npt,k)  // du(k)/dv(k)
+                   + pt_Ju[vth_curr] * x_vth_ie(mpt,npt,k)  // du(k)/dvth(k)
+                   + pt_Ju[dp_curr]  * x_dp_ie (mpt,npt,k)  // du(k)/ddp(k)
+                   + pt_Ju[phi_curr] * x_phi_ie(mpt,npt,k)  // du(k)/dphi(k)
+                   + pt_Ju[w_curr]   * x_w_ie  (mpt,npt,k); // du(k)/dw(k)
 
-          l_v_new += pt_Jv[u_curr]   * l_u_old  (mpt,npt,k)  // dv(k)/du(k)
-                   + pt_Jv[v_curr]   * l_v_old  (mpt,npt,k)  // dv(k)/dv(k)
-                   + pt_Jv[vth_curr] * l_vth_old(mpt,npt,k)  // dv(k)/dvth(k)
-                   + pt_Jv[dp_curr]  * l_dp_old (mpt,npt,k)  // dv(k)/ddp(k)
-                   + pt_Jv[phi_curr] * l_phi_old(mpt,npt,k)  // dv(k)/dphi(k)
-                   + pt_Jv[w_curr]   * l_w_old  (mpt,npt,k); // dv(k)/dw(k)
+          y_v_val += pt_Jv[u_curr]   * x_u_ie  (mpt,npt,k)  // dv(k)/du(k)
+                   + pt_Jv[v_curr]   * x_v_ie  (mpt,npt,k)  // dv(k)/dv(k)
+                   + pt_Jv[vth_curr] * x_vth_ie(mpt,npt,k)  // dv(k)/dvth(k)
+                   + pt_Jv[dp_curr]  * x_dp_ie (mpt,npt,k)  // dv(k)/ddp(k)
+                   + pt_Jv[phi_curr] * x_phi_ie(mpt,npt,k)  // dv(k)/dphi(k)
+                   + pt_Jv[w_curr]   * x_w_ie  (mpt,npt,k); // dv(k)/dw(k)
 
-          l_vth_new += pt_Jvth[u_curr]   * l_u_old  (mpt,npt,k)  // dvth(k)/du(k)
-                     + pt_Jvth[v_curr]   * l_v_old  (mpt,npt,k)  // dvth(k)/dv(k)
-                     + pt_Jvth[vth_curr] * l_vth_old(mpt,npt,k)  // dvth(k)/dvth(k)
-                     + pt_Jvth[dp_curr]  * l_dp_old (mpt,npt,k); // dvth(k)/ddp(k)
+          y_vth_val += pt_Jvth[u_curr]   * x_u_ie  (mpt,npt,k)  // dvth(k)/du(k)
+                     + pt_Jvth[v_curr]   * x_v_ie  (mpt,npt,k)  // dvth(k)/dv(k)
+                     + pt_Jvth[vth_curr] * x_vth_ie(mpt,npt,k)  // dvth(k)/dvth(k)
+                     + pt_Jvth[dp_curr]  * x_dp_ie (mpt,npt,k); // dvth(k)/ddp(k)
 
-          l_dp_new += pt_Jdp[u_curr]  * l_u_old  (mpt,npt,k)  // ddp(k)/du(k)
-                    + pt_Jdp[v_curr]  * l_v_old  (mpt,npt,k)  // ddp(k)/dv(k)
-                    + pt_Jdp[dp_curr] * l_dp_old (mpt,npt,k); // ddp(k)/dp(k)
+          y_dp_val += pt_Jdp[u_curr]  * x_u_ie  (mpt,npt,k)  // ddp(k)/du(k)
+                    + pt_Jdp[v_curr]  * x_v_ie  (mpt,npt,k)  // ddp(k)/dv(k)
+                    + pt_Jdp[dp_curr] * x_dp_ie (mpt,npt,k); // ddp(k)/dp(k)
 
           // Dependencies on k-1 quantities
           if (k>0) {
-            l_u_new += pt_Ju[vth_prev] * l_vth_old(mpt,npt,k-1)  // du(k)/dvth(k-1)
-                     + pt_Ju[dp_prev]  * l_dp_old (mpt,npt,k-1)  // du(k)/ddp(k-1)
-                     + pt_Ju[phi_prev] * l_phi_old(mpt,npt,k-1); // du(k)/dphi(k-1)
+            y_u_val += pt_Ju[vth_prev] * x_vth_ie(mpt,npt,k-1)  // du(k)/dvth(k-1)
+                     + pt_Ju[dp_prev]  * x_dp_ie (mpt,npt,k-1)  // du(k)/ddp(k-1)
+                     + pt_Ju[phi_prev] * x_phi_ie(mpt,npt,k-1); // du(k)/dphi(k-1)
 
-            l_v_new += pt_Jv[vth_prev] * l_vth_old(mpt,npt,k-1)  // dv(k)/dvth(k-1)
-                     + pt_Jv[dp_prev]  * l_dp_old (mpt,npt,k-1)  // dv(k)/ddp(k-1)
-                     + pt_Jv[phi_prev] * l_phi_old(mpt,npt,k-1); // dv(k)/dphi(k-1)
+            y_v_val += pt_Jv[vth_prev] * x_vth_ie(mpt,npt,k-1)  // dv(k)/dvth(k-1)
+                     + pt_Jv[dp_prev]  * x_dp_ie (mpt,npt,k-1)  // dv(k)/ddp(k-1)
+                     + pt_Jv[phi_prev] * x_phi_ie(mpt,npt,k-1); // dv(k)/dphi(k-1)
           }
 
           // Dependencies on k+1 quantities
-          l_u_new += pt_Ju[phi_next] * l_phi_old(mpt,npt,k+1)  // du(k)/dphi(k+1)
-                   + pt_Ju[w_next]   * l_w_old  (mpt,npt,k+1); // du(k)/dw(k+1)
+          y_u_val += pt_Ju[phi_next] * x_phi_ie(mpt,npt,k+1)  // du(k)/dphi(k+1)
+                   + pt_Ju[w_next]   * x_w_ie  (mpt,npt,k+1); // du(k)/dw(k+1)
 
-          l_v_new += pt_Jv[phi_next] * l_phi_old(mpt,npt,k+1)  // dv(k)/dphi(k+1)
-                   + pt_Jv[w_next]   * l_w_old  (mpt,npt,k+1); // dv(k)/dw(k+1)
+          y_v_val += pt_Jv[phi_next] * x_phi_ie(mpt,npt,k+1)  // dv(k)/dphi(k+1)
+                   + pt_Jv[w_next]   * x_w_ie  (mpt,npt,k+1); // dv(k)/dw(k+1)
           if (k<last_mid) {
-            l_u_new += pt_Ju[vth_next]  * l_vth_old(mpt,npt,k+1)  // du(k)/dvth(k+1)
-                     + pt_Ju[dp_next]   * l_dp_old (mpt,npt,k+1)  // du(k)/ddp(k+1)
-                     + pt_Ju[phi_next2] * l_phi_old(mpt,npt,k+2); // du(k)/dphi(k+2)
+            y_u_val += pt_Ju[vth_next]  * x_vth_ie(mpt,npt,k+1)  // du(k)/dvth(k+1)
+                     + pt_Ju[dp_next]   * x_dp_ie (mpt,npt,k+1)  // du(k)/ddp(k+1)
+                     + pt_Ju[phi_next2] * x_phi_ie(mpt,npt,k+2); // du(k)/dphi(k+2)
 
-            l_v_new += pt_Jv[vth_next]  * l_vth_old(mpt,npt,k+1)  // dv(k)/dvth(k+1)
-                     + pt_Jv[dp_next]   * l_dp_old (mpt,npt,k+1)  // dv(k)/ddp(k+1)
-                     + pt_Jv[phi_next2] * l_phi_old(mpt,npt,k+2); // dv(k)/dphi(k+2)
+            y_v_val += pt_Jv[vth_next]  * x_vth_ie(mpt,npt,k+1)  // dv(k)/dvth(k+1)
+                     + pt_Jv[dp_next]   * x_dp_ie (mpt,npt,k+1)  // dv(k)/ddp(k+1)
+                     + pt_Jv[phi_next2] * x_phi_ie(mpt,npt,k+2); // dv(k)/dphi(k+2)
           }
         }
       }
@@ -617,22 +623,22 @@ struct CaarFunctorImplST {
 
     constexpr int last_int = NUM_INTERFACE_LEV-1;
     auto prod_rule_int = KOKKOS_LAMBDA (const int ie, const int ipt, const int jpt, const int k) {
-      const auto& l_u_old   = Homme::subview(l_V,ie,n0,0);
-      const auto& l_v_old   = Homme::subview(l_V,ie,n0,1);
-      const auto& l_vth_old = Homme::subview(l_vth,ie,n0);
-      const auto& l_dp_old  = Homme::subview(l_dp,ie,n0);
-      const auto& l_phi_old = Homme::subview(l_phi,ie,n0);
-      const auto& l_w_old   = Homme::subview(l_w,ie,n0);
+      const auto& x_u_ie   = Homme::subview(x_V,ie,0);
+      const auto& x_v_ie   = Homme::subview(x_V,ie,1);
+      const auto& x_vth_ie = Homme::subview(x_vth,ie);
+      const auto& x_dp_ie  = Homme::subview(x_dp,ie);
+      const auto& x_phi_ie = Homme::subview(x_phi,ie);
+      const auto& x_w_ie   = Homme::subview(x_w,ie);
 
-      auto& l_phi_new = l_phi(ie,np1,ipt,jpt,k);
-      auto& l_w_new   = l_w(ie,np1,ipt,jpt,k);
+      auto& y_phi_val = y_phi(ie,ipt,jpt,k);
+      auto& y_w_val   = y_w(ie,ipt,jpt,k);
 
       // Jacobians
       const auto& Jphi = dphidx_v(ie,np1,ipt,jpt,k).dx();
       const auto& Jw   = dwdx_v(ie,np1,ipt,jpt,k).dx();
 
-      l_phi_new = 0;
-      l_w_new = 0;
+      y_phi_val = 0;
+      y_w_val = 0;
 
       // offsets of each var in the deriv vector
       int u_prev    = offset_u   + (k-1) % 2;
@@ -656,39 +662,39 @@ struct CaarFunctorImplST {
           auto pt_Jw   = Jw   + pt_offset;
 
           // Dependencies on k-th int quantities
-          l_phi_new += pt_Jphi[phi_curr] * l_phi_old(mpt,npt,k)  // dphi(k)/dphi(k)
-                     + pt_Jphi[w_curr]   * l_w_old  (mpt,npt,k); // dphi(k)/dw(k)
+          y_phi_val += pt_Jphi[phi_curr] * x_phi_ie(mpt,npt,k)  // dphi(k)/dphi(k)
+                     + pt_Jphi[w_curr]   * x_w_ie  (mpt,npt,k); // dphi(k)/dw(k)
 
-          l_w_new += pt_Jw[phi_curr] * l_phi_old(mpt,npt,k)  // dw(k)/dphi(k)
-                   + pt_Jw[w_curr]   * l_w_old  (mpt,npt,k); // dw(k)/dw(k)
+          y_w_val += pt_Jw[phi_curr] * x_phi_ie(mpt,npt,k)  // dw(k)/dphi(k)
+                   + pt_Jw[w_curr]   * x_w_ie  (mpt,npt,k); // dw(k)/dw(k)
 
           // Dependency on k-th mid quantities (not defined if k==last_int)
           if (k<last_int) {
-            l_phi_new += pt_Jphi[u_curr]   * l_u_old  (mpt,npt,k)  // dphi(k)/du(k)
-                       + pt_Jphi[v_curr]   * l_v_old  (mpt,npt,k)  // dphi(k)/dv(k)
-                       + pt_Jphi[dp_curr]  * l_dp_old (mpt,npt,k); // dphi(k)/ddp(k)
+            y_phi_val += pt_Jphi[u_curr]   * x_u_ie  (mpt,npt,k)  // dphi(k)/du(k)
+                       + pt_Jphi[v_curr]   * x_v_ie  (mpt,npt,k)  // dphi(k)/dv(k)
+                       + pt_Jphi[dp_curr]  * x_dp_ie (mpt,npt,k); // dphi(k)/ddp(k)
 
-            l_w_new += pt_Jw[u_curr]   * l_u_old  (mpt,npt,k)  // dw(k)/du(k)
-                     + pt_Jw[v_curr]   * l_v_old  (mpt,npt,k)  // dw(k)/dv(k)
-                     + pt_Jw[vth_curr] * l_vth_old(mpt,npt,k)  // dw(k)/dvth(k)
-                     + pt_Jw[dp_curr]  * l_dp_old (mpt,npt,k); // dw(k)/ddp(k)
+            y_w_val += pt_Jw[u_curr]   * x_u_ie  (mpt,npt,k)  // dw(k)/du(k)
+                     + pt_Jw[v_curr]   * x_v_ie  (mpt,npt,k)  // dw(k)/dv(k)
+                     + pt_Jw[vth_curr] * x_vth_ie(mpt,npt,k)  // dw(k)/dvth(k)
+                     + pt_Jw[dp_curr]  * x_dp_ie (mpt,npt,k); // dw(k)/ddp(k)
           }
 
           // Dependencies on k-1 quantities
           if (k>0) {
-            l_phi_new += pt_Jphi[u_prev]  * l_u_old  (mpt,npt,k-1)  // dphi(k)/du(k-1)
-                       + pt_Jphi[v_prev]  * l_v_old  (mpt,npt,k-1)  // dphi(k)/dv(k-1)
-                       + pt_Jphi[dp_prev] * l_dp_old (mpt,npt,k-1); // dphi(k)/ddp(k-1)
+            y_phi_val += pt_Jphi[u_prev]  * x_u_ie  (mpt,npt,k-1)  // dphi(k)/du(k-1)
+                       + pt_Jphi[v_prev]  * x_v_ie  (mpt,npt,k-1)  // dphi(k)/dv(k-1)
+                       + pt_Jphi[dp_prev] * x_dp_ie (mpt,npt,k-1); // dphi(k)/ddp(k-1)
 
-            l_w_new += pt_Jw[u_prev]   * l_u_old  (mpt,npt,k-1)  // dw(k)/du(k-1)
-                     + pt_Jw[v_prev]   * l_v_old  (mpt,npt,k-1)  // dw(k)/dv(k-1)
-                     + pt_Jw[vth_prev] * l_vth_old(mpt,npt,k-1)  // dw(k)/dvth(k-1)
-                     + pt_Jw[dp_prev]  * l_dp_old (mpt,npt,k-1)  // dw(k)/ddp(k-1)
-                     + pt_Jw[phi_prev] * l_phi_old(mpt,npt,k-1); // dw(k)/dphi(k-1)
+            y_w_val += pt_Jw[u_prev]   * x_u_ie  (mpt,npt,k-1)  // dw(k)/du(k-1)
+                     + pt_Jw[v_prev]   * x_v_ie  (mpt,npt,k-1)  // dw(k)/dv(k-1)
+                     + pt_Jw[vth_prev] * x_vth_ie(mpt,npt,k-1)  // dw(k)/dvth(k-1)
+                     + pt_Jw[dp_prev]  * x_dp_ie (mpt,npt,k-1)  // dw(k)/ddp(k-1)
+                     + pt_Jw[phi_prev] * x_phi_ie(mpt,npt,k-1); // dw(k)/dphi(k-1)
           }
           // Dependency on k+1 quantities
           if (k<last_int) {
-            l_w_new += pt_Jw[phi_next] * l_phi_old (mpt,npt,k+1); // dw(k)/dphi(k+1)
+            y_w_val += pt_Jw[phi_next] * x_phi_ie (mpt,npt,k+1); // dw(k)/dphi(k+1)
           }
         }
       }
@@ -757,11 +763,11 @@ struct CaarFunctorImplST {
   //      NP*NP*(NUM_PHYSICAL_LEV*4 + NUM_INTERFACE_LEV*2)
   template<typename MyST = ST>
   std::enable_if_t<not std::is_same_v<MyST,DxFadTypeCaar>>
-  run_JV_full (const RKStageData& data, ElementsStateST<Real>& adj_state) = delete;
+  run_JV_full (const RKStageData& data, const StateSnapshot& x, StateSnapshot& y) = delete;
 
   template<typename MyST = ST>
   std::enable_if_t<std::is_same_v<MyST,DxFadTypeCaar>>
-  run_JV_full (const RKStageData& data, ElementsStateST<Real>& adj_state)
+  run_JV_full (const RKStageData& data, const StateSnapshot& x, StateSnapshot& y)
   {
     // First, init d/dx derivs
     auto dvdx_v = ekat::scalarize(m_state.m_v);
@@ -777,12 +783,17 @@ struct CaarFunctorImplST {
     // Then compute dxnew/dp = dxnew/dxold * dxold/dp
     int np1 = data.np1;
 
-    auto l_V = ekat::scalarize(adj_state.m_v);
-    auto l_vth = ekat::scalarize(adj_state.m_vtheta_dp);
-    auto l_dp = ekat::scalarize(adj_state.m_dp3d);
-    auto l_w = ekat::scalarize(adj_state.m_w_i);
-    auto l_phi = ekat::scalarize(adj_state.m_phinh_i);
+    auto x_V = ekat::scalarize(x.v);
+    auto x_vth = ekat::scalarize(x.vtheta_dp);
+    auto x_dp = ekat::scalarize(x.dp3d);
+    auto x_w = ekat::scalarize(x.w_i);
+    auto x_phi = ekat::scalarize(x.phinh_i);
 
+    auto y_V = ekat::scalarize(y.v);
+    auto y_vth = ekat::scalarize(y.vtheta_dp);
+    auto y_dp = ekat::scalarize(y.dp3d);
+    auto y_w = ekat::scalarize(y.w_i);
+    auto y_phi = ekat::scalarize(y.phinh_i);
     // std::ofstream uf("u.txt");
     // std::ofstream vf("v.txt");
     // std::ofstream vthf("vth.txt");
@@ -808,10 +819,10 @@ struct CaarFunctorImplST {
             // }
 
             // Zero Fad components
-            l_V(ie,np1,0,igp,jgp,lvl) = 0;
-            l_V(ie,np1,1,igp,jgp,lvl) = 0;
-            l_vth(ie,np1,igp,jgp,lvl) = 0;
-            l_dp(ie,np1,igp,jgp,lvl) = 0;
+            y_V(ie,0,igp,jgp,lvl) = 0;
+            y_V(ie,1,igp,jgp,lvl) = 0;
+            y_vth(ie,igp,jgp,lvl) = 0;
+            y_dp(ie,igp,jgp,lvl) = 0;
 
             // Compute mat-vec one row at a time
             int fad_idx = 0;
@@ -819,34 +830,16 @@ struct CaarFunctorImplST {
             for (int sigp=0; sigp<NP; ++sigp) {
               for (int sjgp=0; sjgp<NP; ++sjgp) {
                 for (int slvl=0; slvl<NUM_PHYSICAL_LEV; ++slvl) {
-                  l_V(ie,np1,0,igp,jgp,lvl) +=
-                    dvdx_v(ie,np1,0,igp,jgp,lvl).dx(fad_idx++) * l_V(ie,n0,0,sigp,sjgp,slvl) + 
-                    dvdx_v(ie,np1,0,igp,jgp,lvl).dx(fad_idx++) * l_V(ie,n0,1,sigp,sjgp,slvl) + 
-                    dvdx_v(ie,np1,0,igp,jgp,lvl).dx(fad_idx++) * l_vth(ie,n0,sigp,sjgp,slvl) + 
-                    dvdx_v(ie,np1,0,igp,jgp,lvl).dx(fad_idx++) * l_dp(ie,n0,sigp,sjgp,slvl);
+                  y_V(ie,0,igp,jgp,lvl) +=
+                    dvdx_v(ie,np1,0,igp,jgp,lvl).dx(fad_idx++) * x_V(ie,0,sigp,sjgp,slvl) +
+                    dvdx_v(ie,np1,0,igp,jgp,lvl).dx(fad_idx++) * x_V(ie,1,sigp,sjgp,slvl) +
+                    dvdx_v(ie,np1,0,igp,jgp,lvl).dx(fad_idx++) * x_vth(ie,sigp,sjgp,slvl) +
+                    dvdx_v(ie,np1,0,igp,jgp,lvl).dx(fad_idx++) * x_dp(ie,sigp,sjgp,slvl);
                 }
                 for (int slvl=0; slvl<NUM_INTERFACE_LEV; ++slvl) {
-                  l_V(ie,np1,0,igp,jgp,lvl) +=
-                    dvdx_v(ie,np1,0,igp,jgp,lvl).dx(fad_idx++) * l_w(ie,n0,sigp,sjgp,slvl) +
-                    dvdx_v(ie,np1,0,igp,jgp,lvl).dx(fad_idx++) * l_phi(ie,n0,sigp,sjgp,slvl);
-                }
-              }
-            }
-              
-            fad_idx = 0;
-            for (int sigp=0; sigp<NP; ++sigp) {
-              for (int sjgp=0; sjgp<NP; ++sjgp) {
-                for (int slvl=0; slvl<NUM_PHYSICAL_LEV; ++slvl) {
-                  l_V(ie,np1,1,igp,jgp,lvl) +=
-                    dvdx_v(ie,np1,1,igp,jgp,lvl).dx(fad_idx++) * l_V(ie,n0,0,sigp,sjgp,slvl) + 
-                    dvdx_v(ie,np1,1,igp,jgp,lvl).dx(fad_idx++) * l_V(ie,n0,1,sigp,sjgp,slvl) + 
-                    dvdx_v(ie,np1,1,igp,jgp,lvl).dx(fad_idx++) * l_vth(ie,n0,sigp,sjgp,slvl) + 
-                    dvdx_v(ie,np1,1,igp,jgp,lvl).dx(fad_idx++) * l_dp(ie,n0,sigp,sjgp,slvl);
-                }
-                for (int slvl=0; slvl<NUM_INTERFACE_LEV; ++slvl) {
-                  l_V(ie,np1,1,igp,jgp,lvl) +=
-                    dvdx_v(ie,np1,1,igp,jgp,lvl).dx(fad_idx++) * l_w(ie,n0,sigp,sjgp,slvl) +
-                    dvdx_v(ie,np1,1,igp,jgp,lvl).dx(fad_idx++) * l_phi(ie,n0,sigp,sjgp,slvl);
+                  y_V(ie,0,igp,jgp,lvl) +=
+                    dvdx_v(ie,np1,0,igp,jgp,lvl).dx(fad_idx++) * x_w(ie,sigp,sjgp,slvl) +
+                    dvdx_v(ie,np1,0,igp,jgp,lvl).dx(fad_idx++) * x_phi(ie,sigp,sjgp,slvl);
                 }
               }
             }
@@ -855,16 +848,16 @@ struct CaarFunctorImplST {
             for (int sigp=0; sigp<NP; ++sigp) {
               for (int sjgp=0; sjgp<NP; ++sjgp) {
                 for (int slvl=0; slvl<NUM_PHYSICAL_LEV; ++slvl) {
-                  l_vth(ie,np1,igp,jgp,lvl) +=
-                    dvthdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_V(ie,n0,0,sigp,sjgp,slvl) + 
-                    dvthdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_V(ie,n0,1,sigp,sjgp,slvl) + 
-                    dvthdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_vth(ie,n0,sigp,sjgp,slvl) + 
-                    dvthdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_dp(ie,n0,sigp,sjgp,slvl);
+                  y_V(ie,1,igp,jgp,lvl) +=
+                    dvdx_v(ie,np1,1,igp,jgp,lvl).dx(fad_idx++) * x_V(ie,0,sigp,sjgp,slvl) +
+                    dvdx_v(ie,np1,1,igp,jgp,lvl).dx(fad_idx++) * x_V(ie,1,sigp,sjgp,slvl) +
+                    dvdx_v(ie,np1,1,igp,jgp,lvl).dx(fad_idx++) * x_vth(ie,sigp,sjgp,slvl) +
+                    dvdx_v(ie,np1,1,igp,jgp,lvl).dx(fad_idx++) * x_dp(ie,sigp,sjgp,slvl);
                 }
                 for (int slvl=0; slvl<NUM_INTERFACE_LEV; ++slvl) {
-                  l_vth(ie,np1,igp,jgp,lvl) +=
-                    dvthdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_w(ie,n0,sigp,sjgp,slvl) +
-                    dvthdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_phi(ie,n0,sigp,sjgp,slvl);
+                  y_V(ie,1,igp,jgp,lvl) +=
+                    dvdx_v(ie,np1,1,igp,jgp,lvl).dx(fad_idx++) * x_w(ie,sigp,sjgp,slvl) +
+                    dvdx_v(ie,np1,1,igp,jgp,lvl).dx(fad_idx++) * x_phi(ie,sigp,sjgp,slvl);
                 }
               }
             }
@@ -873,21 +866,38 @@ struct CaarFunctorImplST {
             for (int sigp=0; sigp<NP; ++sigp) {
               for (int sjgp=0; sjgp<NP; ++sjgp) {
                 for (int slvl=0; slvl<NUM_PHYSICAL_LEV; ++slvl) {
-                  l_dp(ie,np1,igp,jgp,lvl) +=
-                    ddpdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_V(ie,n0,0,sigp,sjgp,slvl) + 
-                    ddpdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_V(ie,n0,1,sigp,sjgp,slvl) + 
-                    ddpdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_vth(ie,n0,sigp,sjgp,slvl) + 
-                    ddpdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_dp(ie,n0,sigp,sjgp,slvl);
+                  y_vth(ie,igp,jgp,lvl) +=
+                    dvthdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_V(ie,0,sigp,sjgp,slvl) +
+                    dvthdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_V(ie,1,sigp,sjgp,slvl) +
+                    dvthdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_vth(ie,sigp,sjgp,slvl) +
+                    dvthdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_dp(ie,sigp,sjgp,slvl);
                 }
                 for (int slvl=0; slvl<NUM_INTERFACE_LEV; ++slvl) {
-                  l_dp(ie,np1,igp,jgp,lvl) +=
-                    ddpdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_w(ie,n0,sigp,sjgp,slvl) +
-                    ddpdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_phi(ie,n0,sigp,sjgp,slvl);
+                  y_vth(ie,igp,jgp,lvl) +=
+                    dvthdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_w(ie,sigp,sjgp,slvl) +
+                    dvthdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_phi(ie,sigp,sjgp,slvl);
+                }
+              }
+            }
+
+            fad_idx = 0;
+            for (int sigp=0; sigp<NP; ++sigp) {
+              for (int sjgp=0; sjgp<NP; ++sjgp) {
+                for (int slvl=0; slvl<NUM_PHYSICAL_LEV; ++slvl) {
+                  y_dp(ie,igp,jgp,lvl) +=
+                    ddpdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_V(ie,0,sigp,sjgp,slvl) +
+                    ddpdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_V(ie,1,sigp,sjgp,slvl) +
+                    ddpdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_vth(ie,sigp,sjgp,slvl) +
+                    ddpdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_dp(ie,sigp,sjgp,slvl);
+                }
+                for (int slvl=0; slvl<NUM_INTERFACE_LEV; ++slvl) {
+                  y_dp(ie,igp,jgp,lvl) +=
+                    ddpdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_w(ie,sigp,sjgp,slvl) +
+                    ddpdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_phi(ie,sigp,sjgp,slvl);
                 }
               }
             }
           } // lvl
-        
 
           for (int lvl=0; lvl<NUM_INTERFACE_LEV; ++lvl) {
 
@@ -900,8 +910,8 @@ struct CaarFunctorImplST {
             // }
 
             // Zero Fad components
-            l_w(ie,np1,igp,jgp,lvl) = 0;
-            l_phi(ie,np1,igp,jgp,lvl) = 0;
+            y_w(ie,np1,igp,jgp,lvl) = 0;
+            y_phi(ie,np1,igp,jgp,lvl) = 0;
 
             // Compute mat-vec one row at a time
             int fad_idx = 0;
@@ -909,34 +919,34 @@ struct CaarFunctorImplST {
             for (int sigp=0; sigp<NP; ++sigp) {
               for (int sjgp=0; sjgp<NP; ++sjgp) {
                 for (int slvl=0; slvl<NUM_PHYSICAL_LEV; ++slvl) {
-                  l_w(ie,np1,igp,jgp,lvl) +=
-                    dwdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_V(ie,n0,0,sigp,sjgp,slvl) + 
-                    dwdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_V(ie,n0,1,sigp,sjgp,slvl) + 
-                    dwdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_vth(ie,n0,sigp,sjgp,slvl) + 
-                    dwdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_dp(ie,n0,sigp,sjgp,slvl);
-                } 
+                  y_w(ie,igp,jgp,lvl) +=
+                    dwdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_V(ie,0,sigp,sjgp,slvl) +
+                    dwdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_V(ie,1,sigp,sjgp,slvl) +
+                    dwdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_vth(ie,sigp,sjgp,slvl) +
+                    dwdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_dp(ie,sigp,sjgp,slvl);
+                }
                 for (int slvl=0; slvl<NUM_INTERFACE_LEV; ++slvl) {
-                  l_w(ie,np1,igp,jgp,lvl) +=
-                    dwdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_w(ie,n0,sigp,sjgp,slvl) +
-                    dwdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_phi(ie,n0,sigp,sjgp,slvl);
+                  y_w(ie,igp,jgp,lvl) +=
+                    dwdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_w(ie,sigp,sjgp,slvl) +
+                    dwdx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_phi(ie,sigp,sjgp,slvl);
                 }
               }
             }
-          
+
             fad_idx = 0;
             for (int sigp=0; sigp<NP; ++sigp) {
               for (int sjgp=0; sjgp<NP; ++sjgp) {
                 for (int slvl=0; slvl<NUM_PHYSICAL_LEV; ++slvl) {
-                  l_phi(ie,np1,igp,jgp,lvl) +=
-                    dphidx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_V(ie,n0,0,sigp,sjgp,slvl) + 
-                    dphidx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_V(ie,n0,1,sigp,sjgp,slvl) + 
-                    dphidx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_vth(ie,n0,sigp,sjgp,slvl) + 
-                    dphidx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_dp(ie,n0,sigp,sjgp,slvl);
-                } 
+                  y_phi(ie,igp,jgp,lvl) +=
+                    dphidx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_V(ie,0,sigp,sjgp,slvl) +
+                    dphidx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_V(ie,1,sigp,sjgp,slvl) +
+                    dphidx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_vth(ie,sigp,sjgp,slvl) +
+                    dphidx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_dp(ie,sigp,sjgp,slvl);
+                }
                 for (int slvl=0; slvl<NUM_INTERFACE_LEV; ++slvl) {
-                  l_phi(ie,np1,igp,jgp,lvl) +=
-                    dphidx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_w(ie,n0,sigp,sjgp,slvl) +
-                    dphidx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * l_phi(ie,n0,sigp,sjgp,slvl);
+                  y_phi(ie,igp,jgp,lvl) +=
+                    dphidx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_w(ie,sigp,sjgp,slvl) +
+                    dphidx_v(ie,np1,igp,jgp,lvl).dx(fad_idx++) * x_phi(ie,sigp,sjgp,slvl);
                 }
               }
             }
@@ -956,24 +966,24 @@ struct CaarFunctorImplST {
 
   template<typename MyST = ST>
   std::enable_if_t<not std::is_same_v<MyST,DxFadTypeCaar>>
-  run_JtV (const RKStageData& data, ElementsStateST<Real>& adj_state) = delete;
+  run_JtV (const RKStageData& data, const StateSnapshot& x, StateSnapshot& y) = delete;
 
-  // Computes the transpose Jacobian-vector product: l_new = J^T * l_old,
+  // Computes the transpose Jacobian-vector product: y = J^T * x,
   // where J = d(x_new)/d(x_old) is the same Jacobian used in run_JV.
   // Uses the identical column-compressed stencil (stencil_sz=16), but reverses
   // the accumulation: for each input point (mpt,npt,m) we sum over all Jacobian
   // rows (ipt,jpt,k) whose stencil includes that input point.
   template<typename MyST = ST>
   std::enable_if_t<std::is_same_v<MyST,DxFadTypeCaar>>
-  run_JtV (const RKStageData& data, ElementsStateST<Real>& adj_state)
+  run_JtV (const RKStageData& data, const StateSnapshot& x, StateSnapshot& y)
   {
     // The same compressed-column consideration as in run_JV holds, and everything looks "the same".
-    // There is one important distinction. The indices (i,j,k) for l_new must now match the indices
+    // There is one important distinction. The indices (i,j,k) for y must now match the indices
     // in the deriv, rather than the indices of the var beeing differentiated. That's b/c
     //
     //  [J *v]_i = J_ij * v_j = d(x_i)/d(x_j) * v_j
     //  [J'*v]_i = J_ji * v_j = d(x_j)/d(x_i) * v_j
-    // 
+    //
     // For the gauss points, this is easy to do, as all GPs are coupled with all GPs.
     // For the levels, since we are doing compression, we need to be careful: while in J*v
     // we considered v_j at the levels that can affect x_i, in J'*v we have to consider
@@ -997,29 +1007,34 @@ struct CaarFunctorImplST {
     auto dphidx_v = ekat::scalarize(m_state.m_phinh_i);
     auto dwdx_v = ekat::scalarize(m_state.m_w_i);
 
-    // Compute dxnew/dp = dxnew/dxold * dxold/dp
-    int n0 = data.n0;
+    // Compute Y = d(state_new)/d(state_old) * X
     int np1 = data.np1;
 
-    auto l_V = ekat::scalarize(adj_state.m_v);
-    auto l_vth = ekat::scalarize(adj_state.m_vtheta_dp);
-    auto l_dp = ekat::scalarize(adj_state.m_dp3d);
-    auto l_phi = ekat::scalarize(adj_state.m_phinh_i);
-    auto l_w = ekat::scalarize(adj_state.m_w_i);
-    
+    auto x_V = ekat::scalarize(x.v);
+    auto x_vth = ekat::scalarize(x.vtheta_dp);
+    auto x_dp = ekat::scalarize(x.dp3d);
+    auto x_phi = ekat::scalarize(x.phinh_i);
+    auto x_w = ekat::scalarize(x.w_i);
+
+    auto y_V = ekat::scalarize(y.v);
+    auto y_vth = ekat::scalarize(y.vtheta_dp);
+    auto y_dp = ekat::scalarize(y.dp3d);
+    auto y_phi = ekat::scalarize(y.phinh_i);
+    auto y_w = ekat::scalarize(y.w_i);
+
     constexpr int last_mid = NUM_PHYSICAL_LEV-1;
     auto jtv_mid = KOKKOS_LAMBDA (const int ie, const int ipt, const int jpt, const int k) {
-      const auto& l_u_old   = Homme::subview(l_V,ie,n0,0);
-      const auto& l_v_old   = Homme::subview(l_V,ie,n0,1);
-      const auto& l_vth_old = Homme::subview(l_vth,ie,n0);
-      const auto& l_dp_old  = Homme::subview(l_dp,ie,n0);
-      const auto& l_phi_old = Homme::subview(l_phi,ie,n0);
-      const auto& l_w_old   = Homme::subview(l_w,ie,n0);
+      const auto& x_u_ie   = Homme::subview(x_V,ie,0);
+      const auto& x_v_ie   = Homme::subview(x_V,ie,1);
+      const auto& x_vth_ie = Homme::subview(x_vth,ie);
+      const auto& x_dp_ie  = Homme::subview(x_dp,ie);
+      const auto& x_phi_ie = Homme::subview(x_phi,ie);
+      const auto& x_w_ie   = Homme::subview(x_w,ie);
 
-      auto& l_u_new   = l_V(ie,np1,0,ipt,jpt,k);
-      auto& l_v_new   = l_V(ie,np1,1,ipt,jpt,k);
-      auto& l_vth_new = l_vth(ie,np1,ipt,jpt,k);
-      auto& l_dp_new  = l_dp(ie,np1,ipt,jpt,k);
+      auto& y_u_val   = y_V(ie,0,ipt,jpt,k);
+      auto& y_v_val   = y_V(ie,1,ipt,jpt,k);
+      auto& y_vth_val = y_vth(ie,ipt,jpt,k);
+      auto& y_dp_val  = y_dp(ie,ipt,jpt,k);
 
       // Jacobians
       const auto& Ju   = Homme::subview(dvdx_v,ie,np1,0);
@@ -1029,10 +1044,10 @@ struct CaarFunctorImplST {
       const auto& Jphi = Homme::subview(dphidx_v,ie,np1);
       const auto& Jw   = Homme::subview(dwdx_v,ie,np1);
 
-      l_u_new = 0;
-      l_v_new = 0;
-      l_dp_new = 0;
-      l_vth_new = 0;
+      y_u_val = 0;
+      y_v_val = 0;
+      y_dp_val = 0;
+      y_vth_val = 0;
 
       // offsets of each var in the deriv vector
       // NOTE: to do (X-m) mod n, do (X-m+n) mod n, since the mod of a neg number is not what you think
@@ -1055,59 +1070,59 @@ struct CaarFunctorImplST {
           auto pt_Jw   = Homme::subview(Jw   ,mpt,npt);
 
           // Impacts on k quantities
-          l_u_new += pt_Ju(k).dx(u_curr)   * l_u_old   (mpt,npt,k)  // du(k)/du(k)
-                   + pt_Jv(k).dx(u_curr)   * l_v_old   (mpt,npt,k)  // dv(k)/du(k)
-                   + pt_Jvth(k).dx(u_curr) * l_vth_old (mpt,npt,k)  // dvth(k)/du(k)
-                   + pt_Jdp(k).dx(u_curr)  * l_dp_old  (mpt,npt,k)  // ddp(k)/du(k)
-                   + pt_Jphi(k).dx(u_curr) * l_phi_old (mpt,npt,k)  // dphi(k)/du(k)
-                   + pt_Jw(k).dx(u_curr)   * l_w_old   (mpt,npt,k); // dw(k)/du(k)
+          y_u_val += pt_Ju(k).dx(u_curr)   * x_u_ie  (mpt,npt,k)  // du(k)/du(k)
+                   + pt_Jv(k).dx(u_curr)   * x_v_ie  (mpt,npt,k)  // dv(k)/du(k)
+                   + pt_Jvth(k).dx(u_curr) * x_vth_ie(mpt,npt,k)  // dvth(k)/du(k)
+                   + pt_Jdp(k).dx(u_curr)  * x_dp_ie (mpt,npt,k)  // ddp(k)/du(k)
+                   + pt_Jphi(k).dx(u_curr) * x_phi_ie(mpt,npt,k)  // dphi(k)/du(k)
+                   + pt_Jw(k).dx(u_curr)   * x_w_ie  (mpt,npt,k); // dw(k)/du(k)
 
-          l_v_new += pt_Ju(k).dx(v_curr)   * l_u_old   (mpt,npt,k)  // du(k)/du(k)
-                   + pt_Jv(k).dx(v_curr)   * l_v_old   (mpt,npt,k)  // dv(k)/du(k)
-                   + pt_Jvth(k).dx(v_curr) * l_vth_old (mpt,npt,k)  // dvth(k)/du(k)
-                   + pt_Jdp(k).dx(v_curr)  * l_dp_old  (mpt,npt,k)  // ddp(k)/du(k)
-                   + pt_Jphi(k).dx(v_curr) * l_phi_old (mpt,npt,k)  // dphi(k)/du(k)
-                   + pt_Jw(k).dx(v_curr)   * l_w_old   (mpt,npt,k); // dw(k)/du(k)
+          y_v_val += pt_Ju(k).dx(v_curr)   * x_u_ie  (mpt,npt,k)  // du(k)/du(k)
+                   + pt_Jv(k).dx(v_curr)   * x_v_ie  (mpt,npt,k)  // dv(k)/du(k)
+                   + pt_Jvth(k).dx(v_curr) * x_vth_ie(mpt,npt,k)  // dvth(k)/du(k)
+                   + pt_Jdp(k).dx(v_curr)  * x_dp_ie (mpt,npt,k)  // ddp(k)/du(k)
+                   + pt_Jphi(k).dx(v_curr) * x_phi_ie(mpt,npt,k)  // dphi(k)/du(k)
+                   + pt_Jw(k).dx(v_curr)   * x_w_ie  (mpt,npt,k); // dw(k)/du(k)
 
-          l_vth_new += pt_Ju(k).dx(vth_curr)   * l_u_old   (mpt,npt,k)  // du(k)/dvth(k)
-                    +  pt_Jv(k).dx(vth_curr)   * l_v_old   (mpt,npt,k)  // dv(k)/dvth(k)
-                    +  pt_Jvth(k).dx(vth_curr) * l_vth_old (mpt,npt,k)  // dvth(k)/dvth(k)
-                    +  pt_Jw(k).dx(vth_curr)   * l_w_old   (mpt,npt,k); // dw(k)/dvth(k)
+          y_vth_val += pt_Ju(k).dx(vth_curr)   * x_u_ie  (mpt,npt,k)  // du(k)/dvth(k)
+                    +  pt_Jv(k).dx(vth_curr)   * x_v_ie  (mpt,npt,k)  // dv(k)/dvth(k)
+                    +  pt_Jvth(k).dx(vth_curr) * x_vth_ie(mpt,npt,k)  // dvth(k)/dvth(k)
+                    +  pt_Jw(k).dx(vth_curr)   * x_w_ie  (mpt,npt,k); // dw(k)/dvth(k)
 
-          l_dp_new += pt_Ju(k).dx(dp_curr)   * l_u_old   (mpt,npt,k)  // du(k)/ddp(k)
-                   +  pt_Jv(k).dx(dp_curr)   * l_v_old   (mpt,npt,k)  // dv(k)/ddp(k)
-                   +  pt_Jvth(k).dx(dp_curr) * l_vth_old (mpt,npt,k)  // dvth(k)/ddp(k)
-                   +  pt_Jdp(k).dx(dp_curr)  * l_dp_old  (mpt,npt,k)  // ddp(k)/ddp(k)
-                   +  pt_Jphi(k).dx(dp_curr) * l_phi_old (mpt,npt,k)  // dphi(k)/ddp(k)
-                   +  pt_Jw(k).dx(dp_curr)   * l_w_old   (mpt,npt,k); // dw(k)/ddp(k)
+          y_dp_val += pt_Ju(k).dx(dp_curr)   * x_u_ie  (mpt,npt,k)  // du(k)/ddp(k)
+                   +  pt_Jv(k).dx(dp_curr)   * x_v_ie  (mpt,npt,k)  // dv(k)/ddp(k)
+                   +  pt_Jvth(k).dx(dp_curr) * x_vth_ie(mpt,npt,k)  // dvth(k)/ddp(k)
+                   +  pt_Jdp(k).dx(dp_curr)  * x_dp_ie (mpt,npt,k)  // ddp(k)/ddp(k)
+                   +  pt_Jphi(k).dx(dp_curr) * x_phi_ie(mpt,npt,k)  // dphi(k)/ddp(k)
+                   +  pt_Jw(k).dx(dp_curr)   * x_w_ie  (mpt,npt,k); // dw(k)/ddp(k)
 
           // Impacts on k+1 quantities
-          l_u_new += pt_Jphi(k+1).dx(u_curr) * l_phi_old (mpt,npt,k+1)  // dphi(k+1)/du(k)
-                   + pt_Jw(k+1).dx(u_curr)   * l_w_old   (mpt,npt,k+1); // dw(k+1)/du(k)
+          y_u_val += pt_Jphi(k+1).dx(u_curr) * x_phi_ie(mpt,npt,k+1)  // dphi(k+1)/du(k)
+                   + pt_Jw(k+1).dx(u_curr)   * x_w_ie  (mpt,npt,k+1); // dw(k+1)/du(k)
 
-          l_v_new += pt_Jphi(k+1).dx(v_curr) * l_phi_old (mpt,npt,k+1)  // dphi(k+1)/dv(k)
-                   + pt_Jw(k+1).dx(v_curr)   * l_w_old   (mpt,npt,k+1); // dw(k+1)/dv(k)
+          y_v_val += pt_Jphi(k+1).dx(v_curr) * x_phi_ie(mpt,npt,k+1)  // dphi(k+1)/dv(k)
+                   + pt_Jw(k+1).dx(v_curr)   * x_w_ie  (mpt,npt,k+1); // dw(k+1)/dv(k)
 
-          l_vth_new += pt_Jw(k+1).dx(vth_curr) * l_w_old (mpt,npt,k+1); // dw(k+1)/dvth(k)
+          y_vth_val += pt_Jw(k+1).dx(vth_curr) * x_w_ie(mpt,npt,k+1); // dw(k+1)/dvth(k)
 
-          l_dp_new += pt_Jphi(k+1).dx(dp_curr) * l_phi_old (mpt,npt,k+1)  // dphi(k+1)/ddp(k)
-                    + pt_Jw(k+1).dx(dp_curr)   * l_w_old   (mpt,npt,k+1); // dw(k+1)/ddp(k)
+          y_dp_val += pt_Jphi(k+1).dx(dp_curr) * x_phi_ie(mpt,npt,k+1)  // dphi(k+1)/ddp(k)
+                    + pt_Jw(k+1).dx(dp_curr)   * x_w_ie  (mpt,npt,k+1); // dw(k+1)/ddp(k)
 
           if (k<last_mid) {
-            l_vth_new += pt_Ju(k+1).dx(vth_curr) * l_u_old (mpt,npt,k+1)  // du(k+1)/dvth(k)
-                       + pt_Jv(k+1).dx(vth_curr) * l_v_old (mpt,npt,k+1); // dv(k+1)/dvth(k)
+            y_vth_val += pt_Ju(k+1).dx(vth_curr) * x_u_ie(mpt,npt,k+1)  // du(k+1)/dvth(k)
+                       + pt_Jv(k+1).dx(vth_curr) * x_v_ie(mpt,npt,k+1); // dv(k+1)/dvth(k)
 
-            l_dp_new += pt_Ju(k+1).dx(dp_curr) * l_u_old (mpt,npt,k+1)  // du(k+1)/ddp(k)
-                      + pt_Jv(k+1).dx(dp_curr) * l_v_old (mpt,npt,k+1); // dv(k+1)/ddp(k)
+            y_dp_val += pt_Ju(k+1).dx(dp_curr) * x_u_ie(mpt,npt,k+1)  // du(k+1)/ddp(k)
+                      + pt_Jv(k+1).dx(dp_curr) * x_v_ie(mpt,npt,k+1); // dv(k+1)/ddp(k)
           }
 
           // Impacts on k-1 quantities
           if (k>0) {
-            l_vth_new += pt_Ju(k-1).dx(vth_curr) * l_u_old (mpt,npt,k-1)  // du(k-1)/dvth(k)
-                       + pt_Jv(k-1).dx(vth_curr) * l_v_old (mpt,npt,k-1); // dv(k-1)/dvth(k)
+            y_vth_val += pt_Ju(k-1).dx(vth_curr) * x_u_ie(mpt,npt,k-1)  // du(k-1)/dvth(k)
+                       + pt_Jv(k-1).dx(vth_curr) * x_v_ie(mpt,npt,k-1); // dv(k-1)/dvth(k)
 
-            l_dp_new += pt_Ju(k-1).dx(dp_curr) * l_u_old (mpt,npt,k-1)  // du(k-1)/ddp(k)
-                      + pt_Jv(k-1).dx(dp_curr) * l_v_old (mpt,npt,k-1); // dv(k-1)/ddp(k)
+            y_dp_val += pt_Ju(k-1).dx(dp_curr) * x_u_ie(mpt,npt,k-1)  // du(k-1)/ddp(k)
+                      + pt_Jv(k-1).dx(dp_curr) * x_v_ie(mpt,npt,k-1); // dv(k-1)/ddp(k)
           }
         }
       }
@@ -1115,15 +1130,15 @@ struct CaarFunctorImplST {
 
     constexpr int last_int = NUM_INTERFACE_LEV-1;
     auto jtv_int = KOKKOS_LAMBDA (const int ie, const int ipt, const int jpt, const int k) {
-      const auto& l_u_old   = Homme::subview(l_V,ie,n0,0);
-      const auto& l_v_old   = Homme::subview(l_V,ie,n0,1);
-      const auto& l_vth_old = Homme::subview(l_vth,ie,n0);
-      const auto& l_dp_old  = Homme::subview(l_dp,ie,n0);
-      const auto& l_phi_old = Homme::subview(l_phi,ie,n0);
-      const auto& l_w_old   = Homme::subview(l_w,ie,n0);
+      const auto& x_u_ie   = Homme::subview(x_V,ie,0);
+      const auto& x_v_ie   = Homme::subview(x_V,ie,1);
+      const auto& x_vth_ie = Homme::subview(x_vth,ie);
+      const auto& x_dp_ie  = Homme::subview(x_dp,ie);
+      const auto& x_phi_ie = Homme::subview(x_phi,ie);
+      const auto& x_w_ie   = Homme::subview(x_w,ie);
 
-      auto& l_phi_new = l_phi(ie,np1,ipt,jpt,k);
-      auto& l_w_new   = l_w(ie,np1,ipt,jpt,k);
+      auto& y_phi_val = y_phi(ie,ipt,jpt,k);
+      auto& y_w_val   = y_w(ie,ipt,jpt,k);
 
       // Jacobians
       const auto& Ju   = Homme::subview(dvdx_v,ie,np1,0);
@@ -1133,8 +1148,8 @@ struct CaarFunctorImplST {
       const auto& Jphi = Homme::subview(dphidx_v,ie,np1);
       const auto& Jw   = Homme::subview(dwdx_v,ie,np1);
 
-      l_phi_new = 0;
-      l_w_new = 0;
+      y_phi_val = 0;
+      y_w_val = 0;
 
       int pt_offset = ipt*NP*stencil_sz + jpt*stencil_sz;
 
@@ -1153,40 +1168,40 @@ struct CaarFunctorImplST {
           auto pt_Jw   = Homme::subview(Jw   ,mpt,npt);
 
           // Impacts on k interfaces
-          l_phi_new += pt_Jphi(k).dx(phi_curr) * l_phi_old (mpt,npt,k)  // dphi(k)/dphi(k)
-                     + pt_Jw(k).dx(phi_curr)   * l_w_old   (mpt,npt,k); // dw(k)/dphi(k)
+          y_phi_val += pt_Jphi(k).dx(phi_curr) * x_phi_ie(mpt,npt,k)  // dphi(k)/dphi(k)
+                     + pt_Jw(k).dx(phi_curr)   * x_w_ie  (mpt,npt,k); // dw(k)/dphi(k)
 
-          l_w_new += pt_Jphi(k).dx(w_curr) * l_phi_old (mpt,npt,k)  // dphi(k)/dw(k)
-                   + pt_Jw(k).dx(w_curr)   * l_w_old   (mpt,npt,k); // dw(k)/dw(k)
+          y_w_val += pt_Jphi(k).dx(w_curr) * x_phi_ie(mpt,npt,k)  // dphi(k)/dw(k)
+                   + pt_Jw(k).dx(w_curr)   * x_w_ie  (mpt,npt,k); // dw(k)/dw(k)
 
           // Impacts on k+1 interfaces and k midpoints
           if (k<last_int) {
-            l_phi_new += pt_Ju(k).dx(phi_curr)   * l_u_old (mpt,npt,k)  // du(k)/dphi(k)
-                       + pt_Jv(k).dx(phi_curr)   * l_v_old (mpt,npt,k)  // dv(k)/dphi(k)
-                       + pt_Jw(k+1).dx(phi_curr) * l_w_old (mpt,npt,k+1); // dw(k+1)/dphi(k)
+            y_phi_val += pt_Ju(k).dx(phi_curr)   * x_u_ie(mpt,npt,k)  // du(k)/dphi(k)
+                       + pt_Jv(k).dx(phi_curr)   * x_v_ie(mpt,npt,k)  // dv(k)/dphi(k)
+                       + pt_Jw(k+1).dx(phi_curr) * x_w_ie(mpt,npt,k+1); // dw(k+1)/dphi(k)
 
-            l_w_new += pt_Ju(k).dx(w_curr) * l_u_old (mpt,npt,k)  // du(k)/dw(k)
-                     + pt_Jv(k).dx(w_curr) * l_v_old (mpt,npt,k); // dv(k)/dw(k)
+            y_w_val += pt_Ju(k).dx(w_curr) * x_u_ie(mpt,npt,k)  // du(k)/dw(k)
+                     + pt_Jv(k).dx(w_curr) * x_v_ie(mpt,npt,k); // dv(k)/dw(k)
 
             if (k<last_mid) {
-              l_phi_new += pt_Ju(k+1).dx(phi_curr) * l_u_old (mpt,npt,k+1)  // du(k+1)/dphi(k)
-                         + pt_Jv(k+1).dx(phi_curr) * l_v_old (mpt,npt,k+1); // dv(k+1)/dphi(k)
+              y_phi_val += pt_Ju(k+1).dx(phi_curr) * x_u_ie(mpt,npt,k+1)  // du(k+1)/dphi(k)
+                         + pt_Jv(k+1).dx(phi_curr) * x_v_ie(mpt,npt,k+1); // dv(k+1)/dphi(k)
             }
           }
 
           // Impacts on k-1 quantities
           if (k>0) {
-            l_phi_new += pt_Ju(k-1).dx(phi_curr) * l_u_old  (mpt,npt,k-1)  // du(k-1)/dphi(k)
-                       + pt_Jv(k-1).dx(phi_curr) * l_v_old  (mpt,npt,k-1)  // dv(k-1)/dphi(k)
-                       + pt_Jw(k-1).dx(phi_curr) * l_w_old  (mpt,npt,k-1); // dw(k-1)/dphi(k)
+            y_phi_val += pt_Ju(k-1).dx(phi_curr) * x_u_ie(mpt,npt,k-1)  // du(k-1)/dphi(k)
+                       + pt_Jv(k-1).dx(phi_curr) * x_v_ie(mpt,npt,k-1)  // dv(k-1)/dphi(k)
+                       + pt_Jw(k-1).dx(phi_curr) * x_w_ie(mpt,npt,k-1); // dw(k-1)/dphi(k)
 
-            l_w_new += pt_Ju(k-1).dx(w_curr) * l_u_old  (mpt,npt,k-1)  // du(k-1)/dw(k)
-                     + pt_Jv(k-1).dx(w_curr) * l_v_old  (mpt,npt,k-1); // dv(k-1)/dw(k)
+            y_w_val += pt_Ju(k-1).dx(w_curr) * x_u_ie(mpt,npt,k-1)  // du(k-1)/dw(k)
+                     + pt_Jv(k-1).dx(w_curr) * x_v_ie(mpt,npt,k-1); // dv(k-1)/dw(k)
 
             // Impacts on k-2 quantities
             if (k>1) {
-              l_phi_new += pt_Ju(k-2).dx(phi_curr) * l_u_old  (mpt,npt,k-2)  // du(k-2)/dphi(k)
-                         + pt_Jv(k-2).dx(phi_curr) * l_v_old  (mpt,npt,k-2); // dv(k-2)/dphi(k)
+              y_phi_val += pt_Ju(k-2).dx(phi_curr) * x_u_ie(mpt,npt,k-2)  // du(k-2)/dphi(k)
+                         + pt_Jv(k-2).dx(phi_curr) * x_v_ie(mpt,npt,k-2); // dv(k-2)/dphi(k)
             }
           }
         }
@@ -1202,11 +1217,11 @@ struct CaarFunctorImplST {
   //      NP*NP*(NUM_PHYSICAL_LEV*4 + NUM_INTERFACE_LEV*2)
   template<typename MyST = ST>
   std::enable_if_t<not std::is_same_v<MyST,DxFadTypeCaar>>
-  run_JtV_full (const RKStageData& data, ElementsStateST<Real>& adj_state) = delete;
+  run_JtV_full (const RKStageData& data, const StateSnapshot& x, StateSnapshot& y) = delete;
 
   template<typename MyST = ST>
   std::enable_if_t<std::is_same_v<MyST,DxFadTypeCaar>>
-  run_JtV_full (const RKStageData& data, ElementsStateST<Real>& adj_state)
+  run_JtV_full (const RKStageData& data, const StateSnapshot& x, StateSnapshot& y)
   {
     // First, init d/dx derivs
     auto dvdx_v = ekat::scalarize(m_state.m_v);
@@ -1222,11 +1237,17 @@ struct CaarFunctorImplST {
     // Then compute dxnew/dp = dxnew/dxold * dxold/dp
     int np1 = data.np1;
 
-    auto l_V = ekat::scalarize(adj_state.m_v);
-    auto l_vth = ekat::scalarize(adj_state.m_vtheta_dp);
-    auto l_dp = ekat::scalarize(adj_state.m_dp3d);
-    auto l_w = ekat::scalarize(adj_state.m_w_i);
-    auto l_phi = ekat::scalarize(adj_state.m_phinh_i);
+    auto x_V = ekat::scalarize(x.v);
+    auto x_vth = ekat::scalarize(x.vtheta_dp);
+    auto x_dp = ekat::scalarize(x.dp3d);
+    auto x_w = ekat::scalarize(x.w_i);
+    auto x_phi = ekat::scalarize(x.phinh_i);
+
+    auto y_V = ekat::scalarize(y.v);
+    auto y_vth = ekat::scalarize(y.vtheta_dp);
+    auto y_dp = ekat::scalarize(y.dp3d);
+    auto y_w = ekat::scalarize(y.w_i);
+    auto y_phi = ekat::scalarize(y.phinh_i);
 
     for (int ie=0; ie<m_num_elems; ++ie) {
       int fad_idx = 0;
@@ -1236,44 +1257,25 @@ struct CaarFunctorImplST {
           for (int lvl=0; lvl<NUM_PHYSICAL_LEV; ++lvl) {
 
             // Zero Fad components
-            l_V(ie,np1,0,igp,jgp,lvl) = 0;
-            l_V(ie,np1,1,igp,jgp,lvl) = 0;
-            l_vth(ie,np1,igp,jgp,lvl) = 0;
-            l_dp(ie,np1,igp,jgp,lvl) = 0;
+            y_V(ie,0,igp,jgp,lvl) = 0;
+            y_V(ie,1,igp,jgp,lvl) = 0;
+            y_vth(ie,igp,jgp,lvl) = 0;
+            y_dp(ie,igp,jgp,lvl) = 0;
 
             // Compute mat-trans-vec one column at a time
             for (int sigp=0; sigp<NP; ++sigp) {
               for (int sjgp=0; sjgp<NP; ++sjgp) {
                 for (int slvl=0; slvl<NUM_PHYSICAL_LEV; ++slvl) {
-                  l_V(ie,np1,0,igp,jgp,lvl) +=
-                    dvdx_v(ie,np1,0,sigp,sjgp,slvl).dx(fad_idx) * l_V(ie,n0,0,sigp,sjgp,slvl) + 
-                    dvdx_v(ie,np1,1,sigp,sjgp,slvl).dx(fad_idx) * l_V(ie,n0,1,sigp,sjgp,slvl) + 
-                    dvthdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_vth(ie,n0,sigp,sjgp,slvl) + 
-                    ddpdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_dp(ie,n0,sigp,sjgp,slvl);
+                  y_V(ie,0,igp,jgp,lvl) +=
+                    dvdx_v(ie,np1,0,sigp,sjgp,slvl).dx(fad_idx) * x_V(ie,0,sigp,sjgp,slvl) +
+                    dvdx_v(ie,np1,1,sigp,sjgp,slvl).dx(fad_idx) * x_V(ie,1,sigp,sjgp,slvl) +
+                    dvthdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_vth(ie,sigp,sjgp,slvl) +
+                    ddpdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_dp(ie,sigp,sjgp,slvl);
                 }
                 for (int slvl=0; slvl<NUM_INTERFACE_LEV; ++slvl) {
-                  l_V(ie,np1,0,igp,jgp,lvl) +=
-                    dwdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_w(ie,n0,sigp,sjgp,slvl) +
-                    dphidx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_phi(ie,n0,sigp,sjgp,slvl);
-                }
-              }
-            }
-
-            ++fad_idx;
-            
-            for (int sigp=0; sigp<NP; ++sigp) {
-              for (int sjgp=0; sjgp<NP; ++sjgp) {
-                for (int slvl=0; slvl<NUM_PHYSICAL_LEV; ++slvl) {
-                  l_V(ie,np1,1,igp,jgp,lvl) +=
-                    dvdx_v(ie,np1,0,sigp,sjgp,slvl).dx(fad_idx) * l_V(ie,n0,0,sigp,sjgp,slvl) + 
-                    dvdx_v(ie,np1,1,sigp,sjgp,slvl).dx(fad_idx) * l_V(ie,n0,1,sigp,sjgp,slvl) + 
-                    dvthdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_vth(ie,n0,sigp,sjgp,slvl) + 
-                    ddpdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_dp(ie,n0,sigp,sjgp,slvl);
-                }
-                for (int slvl=0; slvl<NUM_INTERFACE_LEV; ++slvl) {
-                  l_V(ie,np1,1,igp,jgp,lvl) +=
-                    dwdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_w(ie,n0,sigp,sjgp,slvl) +
-                    dphidx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_phi(ie,n0,sigp,sjgp,slvl);
+                  y_V(ie,0,igp,jgp,lvl) +=
+                    dwdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_w(ie,sigp,sjgp,slvl) +
+                    dphidx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_phi(ie,sigp,sjgp,slvl);
                 }
               }
             }
@@ -1283,16 +1285,16 @@ struct CaarFunctorImplST {
             for (int sigp=0; sigp<NP; ++sigp) {
               for (int sjgp=0; sjgp<NP; ++sjgp) {
                 for (int slvl=0; slvl<NUM_PHYSICAL_LEV; ++slvl) {
-                  l_vth(ie,np1,igp,jgp,lvl) +=
-                    dvdx_v(ie,np1,0,sigp,sjgp,slvl).dx(fad_idx) * l_V(ie,n0,0,sigp,sjgp,slvl) + 
-                    dvdx_v(ie,np1,1,sigp,sjgp,slvl).dx(fad_idx) * l_V(ie,n0,1,sigp,sjgp,slvl) + 
-                    dvthdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_vth(ie,n0,sigp,sjgp,slvl) + 
-                    ddpdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_dp(ie,n0,sigp,sjgp,slvl);
+                  y_V(ie,1,igp,jgp,lvl) +=
+                    dvdx_v(ie,np1,0,sigp,sjgp,slvl).dx(fad_idx) * x_V(ie,0,sigp,sjgp,slvl) +
+                    dvdx_v(ie,np1,1,sigp,sjgp,slvl).dx(fad_idx) * x_V(ie,1,sigp,sjgp,slvl) +
+                    dvthdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_vth(ie,sigp,sjgp,slvl) +
+                    ddpdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_dp(ie,sigp,sjgp,slvl);
                 }
                 for (int slvl=0; slvl<NUM_INTERFACE_LEV; ++slvl) {
-                  l_vth(ie,np1,igp,jgp,lvl) +=
-                    dwdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_w(ie,n0,sigp,sjgp,slvl) +
-                    dphidx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_phi(ie,n0,sigp,sjgp,slvl);
+                  y_V(ie,1,igp,jgp,lvl) +=
+                    dwdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_w(ie,sigp,sjgp,slvl) +
+                    dphidx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_phi(ie,sigp,sjgp,slvl);
                 }
               }
             }
@@ -1302,16 +1304,35 @@ struct CaarFunctorImplST {
             for (int sigp=0; sigp<NP; ++sigp) {
               for (int sjgp=0; sjgp<NP; ++sjgp) {
                 for (int slvl=0; slvl<NUM_PHYSICAL_LEV; ++slvl) {
-                  l_dp(ie,np1,igp,jgp,lvl) +=
-                    dvdx_v(ie,np1,0,sigp,sjgp,slvl).dx(fad_idx) * l_V(ie,n0,0,sigp,sjgp,slvl) + 
-                    dvdx_v(ie,np1,1,sigp,sjgp,slvl).dx(fad_idx) * l_V(ie,n0,1,sigp,sjgp,slvl) + 
-                    dvthdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_vth(ie,n0,sigp,sjgp,slvl) + 
-                    ddpdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_dp(ie,n0,sigp,sjgp,slvl);
+                  y_vth(ie,igp,jgp,lvl) +=
+                    dvdx_v(ie,np1,0,sigp,sjgp,slvl).dx(fad_idx) * x_V(ie,0,sigp,sjgp,slvl) +
+                    dvdx_v(ie,np1,1,sigp,sjgp,slvl).dx(fad_idx) * x_V(ie,1,sigp,sjgp,slvl) +
+                    dvthdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_vth(ie,sigp,sjgp,slvl) +
+                    ddpdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_dp(ie,sigp,sjgp,slvl);
                 }
                 for (int slvl=0; slvl<NUM_INTERFACE_LEV; ++slvl) {
-                  l_dp(ie,np1,igp,jgp,lvl) +=
-                    dwdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_w(ie,n0,sigp,sjgp,slvl) +
-                    dphidx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_phi(ie,n0,sigp,sjgp,slvl);
+                  y_vth(ie,igp,jgp,lvl) +=
+                    dwdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_w(ie,sigp,sjgp,slvl) +
+                    dphidx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_phi(ie,sigp,sjgp,slvl);
+                }
+              }
+            }
+
+            ++fad_idx;
+
+            for (int sigp=0; sigp<NP; ++sigp) {
+              for (int sjgp=0; sjgp<NP; ++sjgp) {
+                for (int slvl=0; slvl<NUM_PHYSICAL_LEV; ++slvl) {
+                  y_dp(ie,igp,jgp,lvl) +=
+                    dvdx_v(ie,np1,0,sigp,sjgp,slvl).dx(fad_idx) * x_V(ie,0,sigp,sjgp,slvl) +
+                    dvdx_v(ie,np1,1,sigp,sjgp,slvl).dx(fad_idx) * x_V(ie,1,sigp,sjgp,slvl) +
+                    dvthdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_vth(ie,sigp,sjgp,slvl) +
+                    ddpdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_dp(ie,sigp,sjgp,slvl);
+                }
+                for (int slvl=0; slvl<NUM_INTERFACE_LEV; ++slvl) {
+                  y_dp(ie,igp,jgp,lvl) +=
+                    dwdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_w(ie,sigp,sjgp,slvl) +
+                    dphidx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_phi(ie,sigp,sjgp,slvl);
                 }
               }
             }
@@ -1323,42 +1344,42 @@ struct CaarFunctorImplST {
           for (int lvl=0; lvl<NUM_INTERFACE_LEV; ++lvl) {
 
             // Zero Fad components
-            l_w(ie,np1,igp,jgp,lvl) = 0;
-            l_phi(ie,np1,igp,jgp,lvl) = 0;
+            y_w(ie,igp,jgp,lvl) = 0;
+            y_phi(ie,igp,jgp,lvl) = 0;
 
             // Compute mat-trans-vec one column at a time
             for (int sigp=0; sigp<NP; ++sigp) {
               for (int sjgp=0; sjgp<NP; ++sjgp) {
                 for (int slvl=0; slvl<NUM_PHYSICAL_LEV; ++slvl) {
-                  l_w(ie,np1,igp,jgp,lvl) +=
-                    dvdx_v(ie,np1,0,sigp,sjgp,slvl).dx(fad_idx) * l_V(ie,n0,0,sigp,sjgp,slvl) + 
-                    dvdx_v(ie,np1,1,sigp,sjgp,slvl).dx(fad_idx) * l_V(ie,n0,1,sigp,sjgp,slvl) + 
-                    dvthdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_vth(ie,n0,sigp,sjgp,slvl) + 
-                    ddpdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_dp(ie,n0,sigp,sjgp,slvl);
-                } 
+                  y_w(ie,igp,jgp,lvl) +=
+                    dvdx_v(ie,np1,0,sigp,sjgp,slvl).dx(fad_idx) * x_V(ie,0,sigp,sjgp,slvl) +
+                    dvdx_v(ie,np1,1,sigp,sjgp,slvl).dx(fad_idx) * x_V(ie,1,sigp,sjgp,slvl) +
+                    dvthdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_vth(ie,sigp,sjgp,slvl) +
+                    ddpdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_dp(ie,sigp,sjgp,slvl);
+                }
                 for (int slvl=0; slvl<NUM_INTERFACE_LEV; ++slvl) {
-                  l_w(ie,np1,igp,jgp,lvl) +=
-                    dwdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_w(ie,n0,sigp,sjgp,slvl) +
-                    dphidx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_phi(ie,n0,sigp,sjgp,slvl);
+                  y_w(ie,igp,jgp,lvl) +=
+                    dwdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_w(ie,sigp,sjgp,slvl) +
+                    dphidx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_phi(ie,sigp,sjgp,slvl);
                 }
               }
             }
-          
+
             ++fad_idx;
 
             for (int sigp=0; sigp<NP; ++sigp) {
               for (int sjgp=0; sjgp<NP; ++sjgp) {
                 for (int slvl=0; slvl<NUM_PHYSICAL_LEV; ++slvl) {
-                  l_phi(ie,np1,igp,jgp,lvl) +=
-                    dvdx_v(ie,np1,0,sigp,sjgp,slvl).dx(fad_idx) * l_V(ie,n0,0,sigp,sjgp,slvl) + 
-                    dvdx_v(ie,np1,1,sigp,sjgp,slvl).dx(fad_idx) * l_V(ie,n0,1,sigp,sjgp,slvl) + 
-                    dvthdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_vth(ie,n0,sigp,sjgp,slvl) + 
-                    ddpdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_dp(ie,n0,sigp,sjgp,slvl);
-                } 
+                  y_phi(ie,igp,jgp,lvl) +=
+                    dvdx_v(ie,np1,0,sigp,sjgp,slvl).dx(fad_idx) * x_V(ie,0,sigp,sjgp,slvl) +
+                    dvdx_v(ie,np1,1,sigp,sjgp,slvl).dx(fad_idx) * x_V(ie,1,sigp,sjgp,slvl) +
+                    dvthdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_vth(ie,sigp,sjgp,slvl) +
+                    ddpdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_dp(ie,sigp,sjgp,slvl);
+                }
                 for (int slvl=0; slvl<NUM_INTERFACE_LEV; ++slvl) {
-                  l_phi(ie,np1,igp,jgp,lvl) +=
-                    dwdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_w(ie,n0,sigp,sjgp,slvl) +
-                    dphidx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * l_phi(ie,n0,sigp,sjgp,slvl);
+                  y_phi(ie,igp,jgp,lvl) +=
+                    dwdx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_w(ie,sigp,sjgp,slvl) +
+                    dphidx_v(ie,np1,sigp,sjgp,slvl).dx(fad_idx) * x_phi(ie,sigp,sjgp,slvl);
                 }
               }
             }
@@ -1415,7 +1436,7 @@ struct CaarFunctorImplST {
     compute_dp_and_theta_tens (kv);
 
     // ============= EPOCH 4 =========== //
-    // compute_v_tens reuses some buffers used by compute_dp_and_theta_tens 
+    // compute_v_tens reuses some buffers used by compute_dp_and_theta_tens
     kv.team_barrier();
     compute_v_tens (kv);
 
@@ -1526,7 +1547,7 @@ struct CaarFunctorImplST {
   KOKKOS_INLINE_FUNCTION
   bool compute_scan_quantities (KernelVariables &kv) const {
     bool ok = true;
-    
+
     kv.team_barrier();
     Kokkos::parallel_for(Kokkos::TeamThreadRange(kv.team,NP*NP),
                          [&](const int idx) {

--- a/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
@@ -1007,7 +1007,7 @@ struct CaarFunctorImplST {
     auto dphidx_v = ekat::scalarize(m_state.m_phinh_i);
     auto dwdx_v = ekat::scalarize(m_state.m_w_i);
 
-    // Compute Y = d(state_new)/d(state_old) * X
+    // Compute Y = J^T * X
     int np1 = data.np1;
 
     auto x_V = ekat::scalarize(x.v);

--- a/components/homme/src/theta-l_kokkos/cxx/DirkFunctor.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/DirkFunctor.cpp
@@ -16,6 +16,7 @@ template class DirkFunctorST<Real>;
 
 #ifdef HOMMEXX_ENABLE_FAD_TYPES
 template class DirkFunctorST<DpFadType>;
+template class DirkFunctorST<DxFadTypeDirk>;
 #endif
 
 } // namespace Homme

--- a/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/DirkFunctorImpl.hpp
@@ -167,23 +167,24 @@ struct DirkFunctorImplST {
   static constexpr int fad_offset_w   = 4*NUM_PHYSICAL_LEV;
   static constexpr int fad_offset_phi = 4*NUM_PHYSICAL_LEV + NUM_INTERFACE_LEV;
 
-  // Initialize the d/dx derivatives of the n0 state so that each state variable
+  // Initialize the d/dx derivatives of the state so that each state variable
   // gets a unique FAD index encoding its level. Since DIRK has no horizontal
   // (GaussPoint) coupling, each column (ip,jp) is independent and uses the
-  // same per-level FAD indices.
+  // same per-level FAD indices. The input dx_tl specifies with respect of
+  // which state time level we are computing derivs.
   template<typename MyST = ST>
   std::enable_if_t<std::is_same_v<MyST, DxFadTypeDirk>>
-  init_J (const int n0, const ElementsST<ST>& e) {
-    using md_range_t = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>;
-    const int nelem = e.m_state.num_elems();
-    auto p4_mid = md_range_t({0,0,0,0}, {nelem, NP, NP, NUM_PHYSICAL_LEV});
-    auto p4_int = md_range_t({0,0,0,0}, {nelem, NP, NP, NUM_INTERFACE_LEV});
+  init_J (const int dx_tl, const ElementsStateST<ST>& state) {
+    using md_range_t = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>>;
+    const int nelem = state.num_elems();
+    auto p5_mid = md_range_t({0,0,0,0,0}, {nelem, NUM_TIME_LEVELS, NP, NP, NUM_PHYSICAL_LEV});
+    auto p5_int = md_range_t({0,0,0,0,0}, {nelem, NUM_TIME_LEVELS, NP, NP, NUM_INTERFACE_LEV});
 
-    auto dvdx_v   = ekat::scalarize(e.m_state.m_v);
-    auto dvthdx_v = ekat::scalarize(e.m_state.m_vtheta_dp);
-    auto ddpdx_v  = ekat::scalarize(e.m_state.m_dp3d);
-    auto dwdx_v   = ekat::scalarize(e.m_state.m_w_i);
-    auto dphidx_v = ekat::scalarize(e.m_state.m_phinh_i);
+    auto dvdx_v   = ekat::scalarize(state.m_v);
+    auto dvthdx_v = ekat::scalarize(state.m_vtheta_dp);
+    auto ddpdx_v  = ekat::scalarize(state.m_dp3d);
+    auto dwdx_v   = ekat::scalarize(state.m_w_i);
+    auto dphidx_v = ekat::scalarize(state.m_phinh_i);
 
     // Local copies of offsets for lambda capture (KOKKOS_LAMBDA uses [=])
     const int offset_u   = fad_offset_u;
@@ -193,60 +194,70 @@ struct DirkFunctorImplST {
     const int offset_w   = fad_offset_w;
     const int offset_phi = fad_offset_phi;
 
-    auto init_dx_mid = KOKKOS_LAMBDA (int ie, int ip, int jp, int k) {
-      auto& dudx   = dvdx_v  (ie, n0, 0, ip, jp, k);
-      auto& dvdx   = dvdx_v  (ie, n0, 1, ip, jp, k);
-      auto& dvthdx = dvthdx_v(ie, n0,    ip, jp, k);
-      auto& ddpdx  = ddpdx_v (ie, n0,    ip, jp, k);
+    auto init_dx_mid = KOKKOS_LAMBDA (int ie, int tl, int ip, int jp, int k) {
+      auto& dudx   = dvdx_v  (ie, tl, 0, ip, jp, k);
+      auto& dvdx   = dvdx_v  (ie, tl, 1, ip, jp, k);
+      auto& dvthdx = dvthdx_v(ie, tl,    ip, jp, k);
+      auto& ddpdx  = ddpdx_v (ie, tl,    ip, jp, k);
 
-      dudx.zero();   dudx.fastAccessDx  (offset_u   + k) = 1;
-      dvdx.zero();   dvdx.fastAccessDx  (offset_v   + k) = 1;
-      dvthdx.zero(); dvthdx.fastAccessDx(offset_vth + k) = 1;
-      ddpdx.zero();  ddpdx.fastAccessDx (offset_dp  + k) = 1;
+      auto coeff = tl==dx_tl ? 1 : 0;
+      dudx.zero();   dudx.fastAccessDx  (offset_u   + k) = coeff;
+      dvdx.zero();   dvdx.fastAccessDx  (offset_v   + k) = coeff;
+      dvthdx.zero(); dvthdx.fastAccessDx(offset_vth + k) = coeff;
+      ddpdx.zero();  ddpdx.fastAccessDx (offset_dp  + k) = coeff;
     };
 
-    auto init_dx_int = KOKKOS_LAMBDA (int ie, int ip, int jp, int k) {
-      auto& dwdx   = dwdx_v  (ie, n0, ip, jp, k);
-      auto& dphidx = dphidx_v(ie, n0, ip, jp, k);
+    auto init_dx_int = KOKKOS_LAMBDA (int ie, int tl, int ip, int jp, int k) {
+      auto& dwdx   = dwdx_v  (ie, tl, ip, jp, k);
+      auto& dphidx = dphidx_v(ie, tl, ip, jp, k);
 
-      dwdx.zero();   dwdx.fastAccessDx  (offset_w   + k) = 1;
-      dphidx.zero(); dphidx.fastAccessDx(offset_phi + k) = 1;
+      auto coeff = tl==dx_tl ? 1 : 0;
+      dwdx.zero();   dwdx.fastAccessDx  (offset_w   + k) = coeff;
+      dphidx.zero(); dphidx.fastAccessDx(offset_phi + k) = coeff;
     };
 
-    Kokkos::parallel_for(p4_mid, init_dx_mid);
-    Kokkos::parallel_for(p4_int, init_dx_int);
+    Kokkos::parallel_for(p5_mid, init_dx_mid);
+    Kokkos::parallel_for(p5_int, init_dx_int);
   }
 
-  // Compute the product J*V where J = d(state(np1)) / d(state(n0)).
+  // Compute the product J*V where J = d(state(np1)) / d(state(itl)) (where itl
+  // was set in init_J).
   // DIRK only updates w_i and phinh_i at np1; for v, vtheta_dp, dp3d the
   // Jacobian is the identity (DIRK leaves them unchanged).
-  // Preconditions: init_J(n0,e) and run(...) must have been called first.
-  // On entry:  adj_state at n0 holds the vector V.
-  // On exit:   adj_state at np1 holds J*V for w_i and phinh_i;
-  //            adj_state at np1 holds V unchanged for v, vtheta_dp, dp3d.
+  // Preconditions: init_J(itl,e) and run(...) must have been called first.
+  // The arg state_dx should contain dU(np1)/dU(itl), where itl is the slice
+  // we specified during init_J
   template<typename MyST = ST>
   std::enable_if_t<not std::is_same_v<MyST, DxFadTypeDirk>>
-  run_JV (const int /*n0*/, const int /*np1*/, const ElementsST<ST>& /*e*/,
-          ElementsStateST<Real>& /*adj_state*/) = delete;
+  run_JV (const int /*np1*/, const ElementsStateST<ST>& /*state_dx*/,
+          const StateSnapshot& /* x */, StateSnapshot& /* y */) = delete;
 
   template<typename MyST = ST>
   std::enable_if_t<std::is_same_v<MyST, DxFadTypeDirk>>
-  run_JV (const int n0, const int np1, const ElementsST<ST>& e,
-          ElementsStateST<Real>& adj_state)
+  run_JV (const int np1, const ElementsStateST<ST>& state_dx,
+          const StateSnapshot& x, StateSnapshot& y)
   {
     // Extract the Jacobian-vector product using the product rule.
     // dw_v(ie,np1,ip,jp,k).dx(j) = d(w_np1(ie,ip,jp,k)) / d(input_j)
     // dphi_v(ie,np1,ip,jp,k).dx(j) = d(phi_np1(ie,ip,jp,k)) / d(input_j)
-    const int nelem = e.m_state.num_elems();
+    const int nelem = state_dx.num_elems();
 
-    auto dw_v   = ekat::scalarize(e.m_state.m_w_i);
-    auto dphi_v = ekat::scalarize(e.m_state.m_phinh_i);
+    auto dw_v   = ekat::scalarize(state_dx.m_w_i);
+    auto dphi_v = ekat::scalarize(state_dx.m_phinh_i);
 
-    auto l_V   = ekat::scalarize(adj_state.m_v);
-    auto l_vth = ekat::scalarize(adj_state.m_vtheta_dp);
-    auto l_dp  = ekat::scalarize(adj_state.m_dp3d);
-    auto l_w   = ekat::scalarize(adj_state.m_w_i);
-    auto l_phi = ekat::scalarize(adj_state.m_phinh_i);
+    // Input
+    auto x_V   = ekat::scalarize(x.v);
+    auto x_vth = ekat::scalarize(x.vtheta_dp);
+    auto x_dp  = ekat::scalarize(x.dp3d);
+    auto x_w   = ekat::scalarize(x.w_i);
+    auto x_phi = ekat::scalarize(x.phinh_i);
+
+    // Output
+    auto y_V   = ekat::scalarize(y.v);
+    auto y_vth = ekat::scalarize(y.vtheta_dp);
+    auto y_dp  = ekat::scalarize(y.dp3d);
+    auto y_w   = ekat::scalarize(y.w_i);
+    auto y_phi = ekat::scalarize(y.phinh_i);
 
     // Local copies of offsets for lambda capture
     const int offset_u   = fad_offset_u;
@@ -265,80 +276,88 @@ struct DirkFunctorImplST {
       const auto& Jw   = dw_v  (ie, np1, ip, jp, k).dx();
       const auto& Jphi = dphi_v(ie, np1, ip, jp, k).dx();
 
-      Real l_w_new   = 0;
-      Real l_phi_new = 0;
+      Real y_w_new   = 0;
+      Real y_phi_new = 0;
 
       // Contributions from midpoint variables (u, v, vtheta_dp, dp3d)
       for (int k2 = 0; k2 < NUM_PHYSICAL_LEV; ++k2) {
-        l_w_new   += Jw  [offset_u   + k2] * l_V  (ie, n0, 0, ip, jp, k2)
-                   + Jw  [offset_v   + k2] * l_V  (ie, n0, 1, ip, jp, k2)
-                   + Jw  [offset_vth + k2] * l_vth(ie, n0,    ip, jp, k2)
-                   + Jw  [offset_dp  + k2] * l_dp (ie, n0,    ip, jp, k2);
-        l_phi_new += Jphi[offset_u   + k2] * l_V  (ie, n0, 0, ip, jp, k2)
-                   + Jphi[offset_v   + k2] * l_V  (ie, n0, 1, ip, jp, k2)
-                   + Jphi[offset_vth + k2] * l_vth(ie, n0,    ip, jp, k2)
-                   + Jphi[offset_dp  + k2] * l_dp (ie, n0,    ip, jp, k2);
+        y_w_new   += Jw  [offset_u   + k2] * x_V  (ie, 0, ip, jp, k2)
+                   + Jw  [offset_v   + k2] * x_V  (ie, 1, ip, jp, k2)
+                   + Jw  [offset_vth + k2] * x_vth(ie,    ip, jp, k2)
+                   + Jw  [offset_dp  + k2] * x_dp (ie,    ip, jp, k2);
+        y_phi_new += Jphi[offset_u   + k2] * x_V  (ie, 0, ip, jp, k2)
+                   + Jphi[offset_v   + k2] * x_V  (ie, 1, ip, jp, k2)
+                   + Jphi[offset_vth + k2] * x_vth(ie,    ip, jp, k2)
+                   + Jphi[offset_dp  + k2] * x_dp (ie,    ip, jp, k2);
       }
       // Contributions from interface variables (w_i, phinh_i)
       for (int k2 = 0; k2 < NUM_INTERFACE_LEV; ++k2) {
-        l_w_new   += Jw  [offset_w   + k2] * l_w  (ie, n0, ip, jp, k2)
-                   + Jw  [offset_phi + k2] * l_phi(ie, n0, ip, jp, k2);
-        l_phi_new += Jphi[offset_w   + k2] * l_w  (ie, n0, ip, jp, k2)
-                   + Jphi[offset_phi + k2] * l_phi(ie, n0, ip, jp, k2);
+        y_w_new   += Jw  [offset_w   + k2] * x_w  (ie, ip, jp, k2)
+                   + Jw  [offset_phi + k2] * x_phi(ie, ip, jp, k2);
+        y_phi_new += Jphi[offset_w   + k2] * x_w  (ie, ip, jp, k2)
+                   + Jphi[offset_phi + k2] * x_phi(ie, ip, jp, k2);
       }
 
-      l_w  (ie, np1, ip, jp, k) = l_w_new;
-      l_phi(ie, np1, ip, jp, k) = l_phi_new;
+      y_w  (ie, ip, jp, k) = y_w_new;
+      y_phi(ie, ip, jp, k) = y_phi_new;
     };
 
     // Identity blocks: DIRK does not modify v, vtheta_dp, or dp3d
     auto prod_rule_mid_id = KOKKOS_LAMBDA (const int ie, const int ip, const int jp, const int k) {
-      l_V  (ie, np1, 0, ip, jp, k) = l_V  (ie, n0, 0, ip, jp, k);
-      l_V  (ie, np1, 1, ip, jp, k) = l_V  (ie, n0, 1, ip, jp, k);
-      l_vth(ie, np1,    ip, jp, k) = l_vth(ie, n0,    ip, jp, k);
-      l_dp (ie, np1,    ip, jp, k) = l_dp (ie, n0,    ip, jp, k);
+      y_V  (ie, 0, ip, jp, k) = x_V  (ie, 0, ip, jp, k);
+      y_V  (ie, 1, ip, jp, k) = x_V  (ie, 1, ip, jp, k);
+      y_vth(ie,    ip, jp, k) = x_vth(ie,    ip, jp, k);
+      y_dp (ie,    ip, jp, k) = x_dp (ie,    ip, jp, k);
     };
 
     Kokkos::parallel_for(p4_int, prod_rule_int);
     Kokkos::parallel_for(p4_mid, prod_rule_mid_id);
   }
 
-  // Computes the transpose Jacobian-vector product: l_new = J^T * l_old,
-  // where J = d(state(np1)) / d(state(n0)) is the same Jacobian used in run_JV.
-  // DIRK only updates w_i and phinh_i at np1; for v, vtheta_dp, dp3d the
+  // Compute the product J^T*V where J = d(state(np1)) / d(state(itl)) (where itl
+  // was set in init_J).
+  // DIRK only updates w_i and phinh_i; for v, vtheta_dp, dp3d the
   // Jacobian is the identity (DIRK leaves them unchanged), so J^T also
   // contributes an identity block for those variables.
-  // Preconditions: init_J(n0,e) and run(...) must have been called first.
-  // On entry:  adj_state at n0 holds the vector l_old.
-  // On exit:   adj_state at np1 holds J^T*l_old.
+  // Preconditions: init_J(itl,e) and run(...) must have been called first.
+  // The arg state_dx should contain dU(np1)/dU(itl), where itl is the slice
+  // we specified during init_J
   template<typename MyST = ST>
   std::enable_if_t<not std::is_same_v<MyST, DxFadTypeDirk>>
-  run_JtV (const int /*n0*/, const int /*np1*/, const ElementsST<ST>& /*e*/,
-           ElementsStateST<Real>& /*adj_state*/) = delete;
+  run_JtV (const int /*np1*/, const ElementsStateST<ST>& /*state_dx*/,
+           const StateSnapshot& /*x*/, StateSnapshot& /*y*/) = delete;
 
   template<typename MyST = ST>
   std::enable_if_t<std::is_same_v<MyST, DxFadTypeDirk>>
-  run_JtV (const int n0, const int np1, const ElementsST<ST>& e,
-           ElementsStateST<Real>& adj_state)
+  run_JtV (const int np1, const ElementsStateST<ST>& state_dx,
+           const StateSnapshot& x, StateSnapshot& y)
   {
-    // J has the following block structure (rows = np1 outputs, cols = n0 inputs):
+    // J has the following block structure (rows = np1 outputs, cols = itl inputs):
     //   - Identity block for u, v, vtheta_dp, dp3d (DIRK does not modify them)
     //   - Full blocks for w_i and phinh_i (computed by the Newton solve)
     //
     // J^T therefore:
     //   - For interface inputs (w, phi): sum Jacobian rows of w/phi at np1
     //   - For midpoint inputs (u, v, vth, dp): identity + cross-contributions
-    //     from the w/phi rows of J (since J[w_np1(k), u_n0(k2)] != 0 in general)
-    const int nelem = e.m_state.num_elems();
+    //     from the w/phi rows of J (since J[w_np1(k), u_itl(k2)] != 0 in general)
+    const int nelem = state_dx.num_elems();
 
-    auto dw_v   = ekat::scalarize(e.m_state.m_w_i);
-    auto dphi_v = ekat::scalarize(e.m_state.m_phinh_i);
+    auto dw_v   = ekat::scalarize(state_dx.m_w_i);
+    auto dphi_v = ekat::scalarize(state_dx.m_phinh_i);
 
-    auto l_V   = ekat::scalarize(adj_state.m_v);
-    auto l_vth = ekat::scalarize(adj_state.m_vtheta_dp);
-    auto l_dp  = ekat::scalarize(adj_state.m_dp3d);
-    auto l_w   = ekat::scalarize(adj_state.m_w_i);
-    auto l_phi = ekat::scalarize(adj_state.m_phinh_i);
+    // Input
+    auto x_V   = ekat::scalarize(x.v);
+    auto x_vth = ekat::scalarize(x.vtheta_dp);
+    auto x_dp  = ekat::scalarize(x.dp3d);
+    auto x_w   = ekat::scalarize(x.w_i);
+    auto x_phi = ekat::scalarize(x.phinh_i);
+
+    // Output
+    auto y_V   = ekat::scalarize(y.v);
+    auto y_vth = ekat::scalarize(y.vtheta_dp);
+    auto y_dp  = ekat::scalarize(y.dp3d);
+    auto y_w   = ekat::scalarize(y.w_i);
+    auto y_phi = ekat::scalarize(y.phinh_i);
 
     // Local copies of offsets for lambda capture
     const int offset_u   = fad_offset_u;
@@ -354,34 +373,34 @@ struct DirkFunctorImplST {
 
     // Compute (J^T * l)_w(k2) and (J^T * l)_phi(k2) for interface inputs k2.
     // Each output sums contributions from all interface levels k of the w and phi rows of J.
-    // J^T[w_n0(k2), w_np1(k)]   = J[w_np1(k), w_n0(k2)]   = dw_v(k).dx(offset_w + k2)
-    // J^T[w_n0(k2), phi_np1(k)] = J[phi_np1(k), w_n0(k2)] = dphi_v(k).dx(offset_w + k2)
+    // J^T[w_itl(k2), w_np1(k)]   = J[w_np1(k), w_itl(k2)]   = dw_v(k).dx(offset_w + k2)
+    // J^T[w_itl(k2), phi_np1(k)] = J[phi_np1(k), w_itl(k2)] = dphi_v(k).dx(offset_w + k2)
     // (and similarly for phi input)
     auto jtv_int = KOKKOS_LAMBDA (const int ie, const int ip, const int jp, const int k2) {
-      Real l_w_new   = 0;
-      Real l_phi_new = 0;
+      Real y_w_new   = 0;
+      Real y_phi_new = 0;
 
       for (int k = 0; k < NUM_INTERFACE_LEV; ++k) {
-        const Real l_w_k   = l_w  (ie, n0, ip, jp, k);
-        const Real l_phi_k = l_phi(ie, n0, ip, jp, k);
+        const Real x_w_k   = x_w  (ie, ip, jp, k);
+        const Real x_phi_k = x_phi(ie, ip, jp, k);
 
-        l_w_new   += dw_v  (ie, np1, ip, jp, k).dx(offset_w   + k2) * l_w_k
-                   + dphi_v(ie, np1, ip, jp, k).dx(offset_w   + k2) * l_phi_k;
-        l_phi_new += dw_v  (ie, np1, ip, jp, k).dx(offset_phi + k2) * l_w_k
-                   + dphi_v(ie, np1, ip, jp, k).dx(offset_phi + k2) * l_phi_k;
+        y_w_new   += dw_v  (ie, np1, ip, jp, k).dx(offset_w   + k2) * x_w_k
+                   + dphi_v(ie, np1, ip, jp, k).dx(offset_w   + k2) * x_phi_k;
+        y_phi_new += dw_v  (ie, np1, ip, jp, k).dx(offset_phi + k2) * x_w_k
+                   + dphi_v(ie, np1, ip, jp, k).dx(offset_phi + k2) * x_phi_k;
       }
 
-      l_w  (ie, np1, ip, jp, k2) = l_w_new;
-      l_phi(ie, np1, ip, jp, k2) = l_phi_new;
+      y_w  (ie, ip, jp, k2) = y_w_new;
+      y_phi(ie, ip, jp, k2) = y_phi_new;
     };
 
-    // Compute (J^T * l)_u(k2), _v(k2), _vth(k2), _dp(k2) for midpoint inputs k2.
-    // The identity block contributes the original l_old value; the off-diagonal
+    // Compute (J^T * x)_u(k2), _v(k2), _vth(k2), _dp(k2) for midpoint inputs k2.
+    // The identity block contributes the original x_old value; the off-diagonal
     // contributions come from the w and phi rows of J (since w_np1 and phi_np1
-    // depend on u, v, vtheta_dp, dp3d at n0).
-    // J^T[u_n0(k2), u_np1(k)]   = delta(k,k2)  (identity)
-    // J^T[u_n0(k2), w_np1(k)]   = J[w_np1(k), u_n0(k2)]   = dw_v(k).dx(offset_u + k2)
-    // J^T[u_n0(k2), phi_np1(k)] = J[phi_np1(k), u_n0(k2)] = dphi_v(k).dx(offset_u + k2)
+    // depend on u, v, vtheta_dp, dp3d).
+    // J^T[u_itl(k2), u_np1(k)]   = delta(k,k2)  (identity)
+    // J^T[u_itl(k2), w_np1(k)]   = J[w_np1(k), u_itl(k2)]   = dw_v(k).dx(offset_u + k2)
+    // J^T[u_itl(k2), phi_np1(k)] = J[phi_np1(k), u_itl(k2)] = dphi_v(k).dx(offset_u + k2)
     auto jtv_mid = KOKKOS_LAMBDA (const int ie, const int ip, const int jp, const int k2) {
       Real contrib_u   = 0;
       Real contrib_v   = 0;
@@ -389,24 +408,24 @@ struct DirkFunctorImplST {
       Real contrib_dp  = 0;
 
       for (int k = 0; k < NUM_INTERFACE_LEV; ++k) {
-        const Real l_w_k   = l_w  (ie, n0, ip, jp, k);
-        const Real l_phi_k = l_phi(ie, n0, ip, jp, k);
+        const Real x_w_k   = x_w  (ie, ip, jp, k);
+        const Real x_phi_k = x_phi(ie, ip, jp, k);
 
-        contrib_u   += dw_v  (ie, np1, ip, jp, k).dx(offset_u   + k2) * l_w_k
-                     + dphi_v(ie, np1, ip, jp, k).dx(offset_u   + k2) * l_phi_k;
-        contrib_v   += dw_v  (ie, np1, ip, jp, k).dx(offset_v   + k2) * l_w_k
-                     + dphi_v(ie, np1, ip, jp, k).dx(offset_v   + k2) * l_phi_k;
-        contrib_vth += dw_v  (ie, np1, ip, jp, k).dx(offset_vth + k2) * l_w_k
-                     + dphi_v(ie, np1, ip, jp, k).dx(offset_vth + k2) * l_phi_k;
-        contrib_dp  += dw_v  (ie, np1, ip, jp, k).dx(offset_dp  + k2) * l_w_k
-                     + dphi_v(ie, np1, ip, jp, k).dx(offset_dp  + k2) * l_phi_k;
+        contrib_u   += dw_v  (ie, np1, ip, jp, k).dx(offset_u   + k2) * x_w_k
+                     + dphi_v(ie, np1, ip, jp, k).dx(offset_u   + k2) * x_phi_k;
+        contrib_v   += dw_v  (ie, np1, ip, jp, k).dx(offset_v   + k2) * x_w_k
+                     + dphi_v(ie, np1, ip, jp, k).dx(offset_v   + k2) * x_phi_k;
+        contrib_vth += dw_v  (ie, np1, ip, jp, k).dx(offset_vth + k2) * x_w_k
+                     + dphi_v(ie, np1, ip, jp, k).dx(offset_vth + k2) * x_phi_k;
+        contrib_dp  += dw_v  (ie, np1, ip, jp, k).dx(offset_dp  + k2) * x_w_k
+                     + dphi_v(ie, np1, ip, jp, k).dx(offset_dp  + k2) * x_phi_k;
       }
 
       // Identity block: DIRK does not modify u, v, vtheta_dp, dp3d at np1
-      l_V  (ie, np1, 0, ip, jp, k2) = l_V  (ie, n0, 0, ip, jp, k2) + contrib_u;
-      l_V  (ie, np1, 1, ip, jp, k2) = l_V  (ie, n0, 1, ip, jp, k2) + contrib_v;
-      l_vth(ie, np1,    ip, jp, k2) = l_vth(ie, n0,    ip, jp, k2) + contrib_vth;
-      l_dp (ie, np1,    ip, jp, k2) = l_dp (ie, n0,    ip, jp, k2) + contrib_dp;
+      y_V  (ie, 0, ip, jp, k2) = x_V  (ie, 0, ip, jp, k2) + contrib_u;
+      y_V  (ie, 1, ip, jp, k2) = x_V  (ie, 1, ip, jp, k2) + contrib_v;
+      y_vth(ie,    ip, jp, k2) = x_vth(ie,    ip, jp, k2) + contrib_vth;
+      y_dp (ie,    ip, jp, k2) = x_dp (ie,    ip, jp, k2) + contrib_dp;
     };
 
     Kokkos::parallel_for(p4_int, jtv_int);

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
@@ -7,6 +7,7 @@
 #ifndef HOMMEXX_ELEMENTS_STATE_HPP
 #define HOMMEXX_ELEMENTS_STATE_HPP
 
+#include "StateSnapshot.hpp"
 #include "Types.hpp"
 #include "kokkos_utils.hpp"
 #include "utilities/Hash.hpp"
@@ -36,29 +37,6 @@ private:
   int m_num_elems;
   Kokkos::TeamPolicy<ExecSpace> m_policy;
   TeamUtils<ExecSpace> m_tu;
-};
-
-struct StateSnapshot {
-  using ST = Real;
-  using PT = PackType<ST>;
-
-  StateSnapshot (int nelem, bool alloc_ps = false)
-   : v ("v",nelem)
-   , vtheta_dp ("vtheta_dp",nelem)
-   , dp3d ("dp3d",nelem)
-   , w_i ("w",nelem)
-   , phinh_i ("phinh",nelem)
-  {
-    if (alloc_ps)
-      ps_v = decltype(ps_v)("ps",nelem);
-  }
-
-  ExecViewManaged<PT * [2][NP][NP][NUM_LEV  ]> v;          // Horizontal velocity
-  ExecViewManaged<PT *    [NP][NP][NUM_LEV  ]> vtheta_dp;  // Virtual potential temperature (mass)
-  ExecViewManaged<PT *    [NP][NP][NUM_LEV  ]> dp3d;       // Delta p on levels
-  ExecViewManaged<PT *    [NP][NP][NUM_LEV_P]> w_i;        // Vertical velocity at interfaces
-  ExecViewManaged<PT *    [NP][NP][NUM_LEV_P]> phinh_i;    // Geopotential used by NH model at interfaces
-  ExecViewManaged<ST *    [NP][NP]           > ps_v;       // Surface pressure
 };
 
 /* Per element data - specific velocity, temperature, pressure, etc. */

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
@@ -106,19 +106,8 @@ public:
 #ifdef HOMMEXX_ENABLE_FAD_TYPES
   void randomize_derivs(const int seed, const int itl);
 
-  template<typename MyST = ST>
-  std::enable_if_t<not Sacado::IsFad<MyST>::value,StateSnapshot>
-  take_deriv_snapshot (int tl, int ider, bool do_ps = false) = delete;
-  template<typename MyST = ST>
-  std::enable_if_t<not Sacado::IsFad<MyST>::value>
-  take_deriv_snapshot (StateSnapshot& snap, int tl, int ider, bool do_ps = false) = delete;
-
-  template<typename MyST = ST>
-  std::enable_if_t<Sacado::IsFad<MyST>::value,StateSnapshot>
-  take_deriv_snapshot (int tl, int ider, bool do_ps = false);
-  template<typename MyST = ST>
-  std::enable_if_t<Sacado::IsFad<MyST>::value>
-  take_deriv_snapshot (StateSnapshot& snap, int tl, int ider, bool do_ps = false);
+  StateSnapshot take_deriv_snapshot (int tl, int ider, bool do_ps = false);
+  void take_deriv_snapshot (StateSnapshot& snap, int tl, int ider, bool do_ps = false);
 #endif
 
 private:

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState.hpp
@@ -13,6 +13,7 @@
 #include "utilities/Hash.hpp"
 
 #include <ekat_pack_kokkos.hpp>
+#include <ekat_assert.hpp>
 
 namespace Homme {
 
@@ -88,7 +89,9 @@ public:
   template<typename RST>
   void import_values (const ElementsStateST<RST>& rhs, int tl);
 
-  StateSnapshot export_values (int tl, bool do_ps = false);
+  StateSnapshot take_snapshot (int tl, bool do_ps = false);
+  void take_snapshot (StateSnapshot& snap, int tl, bool do_ps = false);
+  void import_snapshot (const StateSnapshot& snap, int tl, bool do_ps = false);
 
   // Check ElementsState for NaN or incorrectly signed values. The initial check
   // is fast and on device. If everything is fine, the routine returns
@@ -103,9 +106,19 @@ public:
 #ifdef HOMMEXX_ENABLE_FAD_TYPES
   void randomize_derivs(const int seed, const int itl);
 
-  template<typename RST>
-  std::enable_if_t<Sacado::IsFad<RST>::value>
-  import_values_from_deriv (const ElementsStateST<RST>& rhs, int tl, int ider);
+  template<typename MyST = ST>
+  std::enable_if_t<not Sacado::IsFad<MyST>::value,StateSnapshot>
+  take_deriv_snapshot (int tl, int ider, bool do_ps = false) = delete;
+  template<typename MyST = ST>
+  std::enable_if_t<not Sacado::IsFad<MyST>::value>
+  take_deriv_snapshot (StateSnapshot& snap, int tl, int ider, bool do_ps = false) = delete;
+
+  template<typename MyST = ST>
+  std::enable_if_t<Sacado::IsFad<MyST>::value,StateSnapshot>
+  take_deriv_snapshot (int tl, int ider, bool do_ps = false);
+  template<typename MyST = ST>
+  std::enable_if_t<Sacado::IsFad<MyST>::value>
+  take_deriv_snapshot (StateSnapshot& snap, int tl, int ider, bool do_ps = false);
 #endif
 
 private:
@@ -160,50 +173,6 @@ void ElementsStateST<ST>::import_values (const ElementsStateST<RST>& rhs, int tl
   Kokkos::MDRangePolicy<ExecSpace,Kokkos::Rank<4>> p({0,0,0,0},{m_num_elems,NP,NP,nlev});
   Kokkos::parallel_for(p,copy);
 }
-
-#ifdef HOMMEXX_ENABLE_FAD_TYPES
-// Extract derivs from an ElementStateST templated on a Fad type into one that has ST=Real
-template<typename ST>
-template<typename RST>
-std::enable_if_t<Sacado::IsFad<RST>::value>
-ElementsStateST<ST>::import_values_from_deriv (const ElementsStateST<RST>& rhs, int tl, int ider)
-{
-  EKAT_REQUIRE_MSG (ider>=0 and ider<DerivSz<RST>::value,
-      "[ElementsStateST::import_values_from_deriv] Error! Derivative index (" << ider << ") out of bounds.\n");
-  auto lhs_v = ekat::scalarize(m_v);
-  auto lhs_dp = ekat::scalarize(m_dp3d);
-  auto lhs_phi = ekat::scalarize(m_phinh_i);
-  auto lhs_vth = ekat::scalarize(m_vtheta_dp);
-  auto lhs_w = ekat::scalarize(m_w_i);
-  auto lhs_ps = ekat::scalarize(m_ps_v);
-
-  auto rhs_v = ekat::scalarize(rhs.m_v);
-  auto rhs_dp = ekat::scalarize(rhs.m_dp3d);
-  auto rhs_phi = ekat::scalarize(rhs.m_phinh_i);
-  auto rhs_vth = ekat::scalarize(rhs.m_vtheta_dp);
-  auto rhs_w = ekat::scalarize(rhs.m_w_i);
-  auto rhs_ps = ekat::scalarize(rhs.m_ps_v);
-
-  int nlev = NUM_PHYSICAL_LEV;
-  auto copy = KOKKOS_LAMBDA(int ie, int ip, int jp, int k) {
-    lhs_v(ie,tl,0,ip,jp,k) = rhs_v(ie,tl,0,ip,jp,k).fastAccessDx(ider);
-    lhs_v(ie,tl,1,ip,jp,k) = rhs_v(ie,tl,1,ip,jp,k).fastAccessDx(ider);
-
-    lhs_w(ie,tl,ip,jp,k)   = rhs_w(ie,tl,ip,jp,k).fastAccessDx(ider);
-    lhs_dp(ie,tl,ip,jp,k)  = rhs_dp(ie,tl,ip,jp,k).fastAccessDx(ider);
-    lhs_vth(ie,tl,ip,jp,k) = rhs_vth(ie,tl,ip,jp,k).fastAccessDx(ider);
-    lhs_phi(ie,tl,ip,jp,k) = rhs_phi(ie,tl,ip,jp,k).fastAccessDx(ider);
-
-    if (k==0) {
-      lhs_ps(ie,tl,ip,jp) = rhs_ps(ie,tl,ip,jp).fastAccessDx(ider);
-      lhs_w(ie,tl,ip,jp,nlev) = rhs_w(ie,tl,ip,jp,nlev).fastAccessDx(ider);
-      lhs_phi(ie,tl,ip,jp,nlev) = rhs_phi(ie,tl,ip,jp,nlev).fastAccessDx(ider);
-    }
-  };
-  Kokkos::MDRangePolicy<ExecSpace,Kokkos::Rank<4>> p({0,0,0,0},{m_num_elems,NP,NP,nlev});
-  Kokkos::parallel_for(p,copy);
-}
-#endif // HOMMEXX_ENABLE_FAD_TYPES
 
 } // Homme
 

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState_def.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState_def.hpp
@@ -565,10 +565,22 @@ HashType ElementsStateST<ST>::hash (const int tl) const {
 }
 
 template<typename ST>
-StateSnapshot ElementsStateST<ST>::export_values (int tl, bool do_ps)
+StateSnapshot ElementsStateST<ST>::take_snapshot (int tl, bool do_ps)
 {
-  constexpr auto NPL = NUM_PHYSICAL_LEV;
   StateSnapshot snap(m_num_elems,do_ps);
+  take_snapshot(snap,tl,do_ps);
+  return snap;
+}
+
+template<typename ST>
+void ElementsStateST<ST>::take_snapshot (StateSnapshot& snap, int tl, bool do_ps)
+{
+  EKAT_REQUIRE_MSG(snap.num_elems == m_num_elems,
+       "[ElementsStateST::take_snapshot] Error! Snapshot has wrong num_elems.\n");
+   EKAT_REQUIRE_MSG(!do_ps || snap.ps_v.data() != nullptr,
+       "[ElementsStateST::take_snapshot] Error! do_ps=true but snapshot.ps_v is not allocated.\n");
+
+  constexpr auto NPL = NUM_PHYSICAL_LEV;
 
   auto v   = ekat::scalarize(m_v);
   auto vth = ekat::scalarize(m_vtheta_dp);
@@ -600,8 +612,108 @@ StateSnapshot ElementsStateST<ST>::export_values (int tl, bool do_ps)
 
   Kokkos::MDRangePolicy<ExecSpace,Kokkos::Rank<4>> policy({0,0,0,0},{m_num_elems,NP,NP,NUM_PHYSICAL_LEV});
   Kokkos::parallel_for(policy,copy);
+}
+
+template<typename ST>
+void ElementsStateST<ST>::import_snapshot (const StateSnapshot& snap, int tl, bool do_ps)
+{
+   EKAT_REQUIRE_MSG(snap.num_elems == m_num_elems,
+       "[ElementsStateST::import_snapshot] Error! Snapshot has wrong num_elems.\n");
+   EKAT_REQUIRE_MSG(!do_ps || snap.ps_v.data() != nullptr,
+       "[ElementsStateST::import_snapshot] Error! do_ps=true but snapshot.ps_v is not allocated.\n");
+
+  constexpr auto NPL = NUM_PHYSICAL_LEV;
+
+  auto v   = ekat::scalarize(m_v);
+  auto vth = ekat::scalarize(m_vtheta_dp);
+  auto dp  = ekat::scalarize(m_dp3d);
+  auto w   = ekat::scalarize(m_w_i);
+  auto phi = ekat::scalarize(m_phinh_i);
+  auto ps  = ekat::scalarize(m_ps_v);
+  auto snap_v   = ekat::scalarize(snap.v);
+  auto snap_vth = ekat::scalarize(snap.vtheta_dp);
+  auto snap_dp  = ekat::scalarize(snap.dp3d);
+  auto snap_w   = ekat::scalarize(snap.w_i);
+  auto snap_phi = ekat::scalarize(snap.phinh_i);
+  auto snap_ps  = ekat::scalarize(snap.ps_v);
+  auto copy = KOKKOS_LAMBDA (int ie, int ip, int jp, int k) {
+    v  (ie,tl,0,ip,jp,k) = snap_v  (ie,0,ip,jp,k);
+    v  (ie,tl,1,ip,jp,k) = snap_v  (ie,1,ip,jp,k);
+    vth(ie,tl  ,ip,jp,k) = snap_vth(ie,  ip,jp,k);
+    dp (ie,tl  ,ip,jp,k) = snap_dp (ie,  ip,jp,k);
+    w  (ie,tl  ,ip,jp,k) = snap_w  (ie,  ip,jp,k);
+    phi(ie,tl  ,ip,jp,k) = snap_phi(ie,  ip,jp,k);
+    if (do_ps) {
+      ps(ie,tl,ip,jp) = snap_ps(ie,ip,jp);
+    }
+    if (k==NPL-1) {
+      w  (ie,tl,ip,jp,NPL) = snap_w  (ie,ip,jp,NPL);
+      phi(ie,tl,ip,jp,NPL) = snap_phi(ie,ip,jp,NPL);
+    }
+  };
+
+  Kokkos::MDRangePolicy<ExecSpace,Kokkos::Rank<4>> policy({0,0,0,0},{m_num_elems,NP,NP,NUM_PHYSICAL_LEV});
+  Kokkos::parallel_for(policy,copy);
+}
+
+#ifdef HOMMEXX_ENABLE_FAD_TYPES
+// Extract derivs from an ElementStateST templated on a Fad type into one that has ST=Real
+template<typename ST>
+template<typename MyST>
+std::enable_if_t<Sacado::IsFad<MyST>::value,StateSnapshot>
+ElementsStateST<ST>::take_deriv_snapshot (int tl, int ider, bool do_ps)
+{
+  StateSnapshot snap(m_num_elems,do_ps);
+  take_deriv_snapshot(snap,tl,ider,do_ps);
   return snap;
 }
+
+template<typename ST>
+template<typename MyST>
+std::enable_if_t<Sacado::IsFad<MyST>::value>
+ElementsStateST<ST>::take_deriv_snapshot (StateSnapshot& snap, int tl, int ider, bool do_ps)
+{
+   EKAT_REQUIRE_MSG (ider>=0 and ider<DerivSz<MyST>::value,
+       "[ElementsStateST::take_deriv_snapshot] Error! Derivative index (" << ider << ") out of bounds.\n");
+   EKAT_REQUIRE_MSG(snap.num_elems == m_num_elems,
+       "[ElementsStateST::take_deriv_snapshot] Error! Snapshot has wrong num_elems.\n");
+   EKAT_REQUIRE_MSG(!do_ps || snap.ps_v.data() != nullptr,
+       "[ElementsStateST::take_deriv_snapshot] Error! do_ps=true but snapshot.ps_v is not allocated.\n");
+
+  constexpr auto NPL = NUM_PHYSICAL_LEV;
+
+  auto v   = ekat::scalarize(m_v);
+  auto vth = ekat::scalarize(m_vtheta_dp);
+  auto dp  = ekat::scalarize(m_dp3d);
+  auto w   = ekat::scalarize(m_w_i);
+  auto phi = ekat::scalarize(m_phinh_i);
+  auto ps  = ekat::scalarize(m_ps_v);
+  auto snap_v   = ekat::scalarize(snap.v);
+  auto snap_vth = ekat::scalarize(snap.vtheta_dp);
+  auto snap_dp  = ekat::scalarize(snap.dp3d);
+  auto snap_w   = ekat::scalarize(snap.w_i);
+  auto snap_phi = ekat::scalarize(snap.phinh_i);
+  auto snap_ps  = ekat::scalarize(snap.ps_v);
+  auto copy = KOKKOS_LAMBDA (int ie, int ip, int jp, int k) {
+    snap_v  (ie,0,ip,jp,k) = v  (ie,tl,0,ip,jp,k).fastAccessDx(ider);
+    snap_v  (ie,1,ip,jp,k) = v  (ie,tl,1,ip,jp,k).fastAccessDx(ider);
+    snap_vth(ie,  ip,jp,k) = vth(ie,tl  ,ip,jp,k).fastAccessDx(ider);
+    snap_dp (ie,  ip,jp,k) = dp (ie,tl  ,ip,jp,k).fastAccessDx(ider);
+    snap_w  (ie,  ip,jp,k) = w  (ie,tl  ,ip,jp,k).fastAccessDx(ider);
+    snap_phi(ie,  ip,jp,k) = phi(ie,tl  ,ip,jp,k).fastAccessDx(ider);
+    if (do_ps) {
+      snap_ps(ie,ip,jp) = ps(ie,tl,ip,jp).fastAccessDx(ider);
+    }
+    if (k==NPL-1) {
+      snap_w  (ie,ip,jp,NPL) = w  (ie,tl,ip,jp,NPL).fastAccessDx(ider);
+      snap_phi(ie,ip,jp,NPL) = phi(ie,tl,ip,jp,NPL).fastAccessDx(ider);
+    }
+  };
+
+  Kokkos::MDRangePolicy<ExecSpace,Kokkos::Rank<4>> policy({0,0,0,0},{m_num_elems,NP,NP,NUM_PHYSICAL_LEV});
+  Kokkos::parallel_for(policy,copy);
+}
+#endif // HOMMEXX_ENABLE_FAD_TYPES
 
 } // namespace Homme
 

--- a/components/homme/src/theta-l_kokkos/cxx/ElementsState_def.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/ElementsState_def.hpp
@@ -658,10 +658,9 @@ void ElementsStateST<ST>::import_snapshot (const StateSnapshot& snap, int tl, bo
 
 #ifdef HOMMEXX_ENABLE_FAD_TYPES
 // Extract derivs from an ElementStateST templated on a Fad type into one that has ST=Real
+
 template<typename ST>
-template<typename MyST>
-std::enable_if_t<Sacado::IsFad<MyST>::value,StateSnapshot>
-ElementsStateST<ST>::take_deriv_snapshot (int tl, int ider, bool do_ps)
+StateSnapshot ElementsStateST<ST>::take_deriv_snapshot (int tl, int ider, bool do_ps)
 {
   StateSnapshot snap(m_num_elems,do_ps);
   take_deriv_snapshot(snap,tl,ider,do_ps);
@@ -669,49 +668,56 @@ ElementsStateST<ST>::take_deriv_snapshot (int tl, int ider, bool do_ps)
 }
 
 template<typename ST>
-template<typename MyST>
-std::enable_if_t<Sacado::IsFad<MyST>::value>
-ElementsStateST<ST>::take_deriv_snapshot (StateSnapshot& snap, int tl, int ider, bool do_ps)
+void ElementsStateST<ST>::take_deriv_snapshot (StateSnapshot& snap, int tl, int ider, bool do_ps)
 {
-   EKAT_REQUIRE_MSG (ider>=0 and ider<DerivSz<MyST>::value,
-       "[ElementsStateST::take_deriv_snapshot] Error! Derivative index (" << ider << ") out of bounds.\n");
-   EKAT_REQUIRE_MSG(snap.num_elems == m_num_elems,
-       "[ElementsStateST::take_deriv_snapshot] Error! Snapshot has wrong num_elems.\n");
-   EKAT_REQUIRE_MSG(!do_ps || snap.ps_v.data() != nullptr,
-       "[ElementsStateST::take_deriv_snapshot] Error! do_ps=true but snapshot.ps_v is not allocated.\n");
+  EKAT_REQUIRE_MSG (Sacado::IsFad<ST>::value,
+      "[ElementsStateST::take_deriv_snapshot] Error! The template type ST is not a Sacado type.\n");
+  EKAT_REQUIRE_MSG (ider>=0 and ider<DerivSz<ST>::value,
+      "[ElementsStateST::take_deriv_snapshot] Error! Derivative index (" << ider << ") out of bounds.\n");
+  EKAT_REQUIRE_MSG(snap.num_elems == m_num_elems,
+      "[ElementsStateST::take_deriv_snapshot] Error! Snapshot has wrong num_elems.\n");
+  EKAT_REQUIRE_MSG(!do_ps || snap.ps_v.data() != nullptr,
+      "[ElementsStateST::take_deriv_snapshot] Error! do_ps=true but snapshot.ps_v is not allocated.\n");
 
-  constexpr auto NPL = NUM_PHYSICAL_LEV;
+  // Note: we do need the generic lambda to go past the 1st template compilation pass.
+  // Without, the method would not compiler when ST is not a Sacado type
+  auto do_take = [&] (auto& v, auto& vth, auto& dp, auto& w, auto& phi, auto& ps) {
+    constexpr auto NPL = NUM_PHYSICAL_LEV;
+    auto snap_v   = ekat::scalarize(snap.v);
+    auto snap_vth = ekat::scalarize(snap.vtheta_dp);
+    auto snap_dp  = ekat::scalarize(snap.dp3d);
+    auto snap_w   = ekat::scalarize(snap.w_i);
+    auto snap_phi = ekat::scalarize(snap.phinh_i);
+    auto snap_ps  = ekat::scalarize(snap.ps_v);
+    auto copy = KOKKOS_LAMBDA (int ie, int ip, int jp, int k) {
+      snap_v  (ie,0,ip,jp,k) = v  (ie,tl,0,ip,jp,k).fastAccessDx(ider);
+      snap_v  (ie,1,ip,jp,k) = v  (ie,tl,1,ip,jp,k).fastAccessDx(ider);
+      snap_vth(ie,  ip,jp,k) = vth(ie,tl  ,ip,jp,k).fastAccessDx(ider);
+      snap_dp (ie,  ip,jp,k) = dp (ie,tl  ,ip,jp,k).fastAccessDx(ider);
+      snap_w  (ie,  ip,jp,k) = w  (ie,tl  ,ip,jp,k).fastAccessDx(ider);
+      snap_phi(ie,  ip,jp,k) = phi(ie,tl  ,ip,jp,k).fastAccessDx(ider);
+      if (do_ps) {
+        snap_ps(ie,ip,jp) = ps(ie,tl,ip,jp).fastAccessDx(ider);
+      }
+      if (k==NPL-1) {
+        snap_w  (ie,ip,jp,NPL) = w  (ie,tl,ip,jp,NPL).fastAccessDx(ider);
+        snap_phi(ie,ip,jp,NPL) = phi(ie,tl,ip,jp,NPL).fastAccessDx(ider);
+      }
+    };
 
-  auto v   = ekat::scalarize(m_v);
-  auto vth = ekat::scalarize(m_vtheta_dp);
-  auto dp  = ekat::scalarize(m_dp3d);
-  auto w   = ekat::scalarize(m_w_i);
-  auto phi = ekat::scalarize(m_phinh_i);
-  auto ps  = ekat::scalarize(m_ps_v);
-  auto snap_v   = ekat::scalarize(snap.v);
-  auto snap_vth = ekat::scalarize(snap.vtheta_dp);
-  auto snap_dp  = ekat::scalarize(snap.dp3d);
-  auto snap_w   = ekat::scalarize(snap.w_i);
-  auto snap_phi = ekat::scalarize(snap.phinh_i);
-  auto snap_ps  = ekat::scalarize(snap.ps_v);
-  auto copy = KOKKOS_LAMBDA (int ie, int ip, int jp, int k) {
-    snap_v  (ie,0,ip,jp,k) = v  (ie,tl,0,ip,jp,k).fastAccessDx(ider);
-    snap_v  (ie,1,ip,jp,k) = v  (ie,tl,1,ip,jp,k).fastAccessDx(ider);
-    snap_vth(ie,  ip,jp,k) = vth(ie,tl  ,ip,jp,k).fastAccessDx(ider);
-    snap_dp (ie,  ip,jp,k) = dp (ie,tl  ,ip,jp,k).fastAccessDx(ider);
-    snap_w  (ie,  ip,jp,k) = w  (ie,tl  ,ip,jp,k).fastAccessDx(ider);
-    snap_phi(ie,  ip,jp,k) = phi(ie,tl  ,ip,jp,k).fastAccessDx(ider);
-    if (do_ps) {
-      snap_ps(ie,ip,jp) = ps(ie,tl,ip,jp).fastAccessDx(ider);
-    }
-    if (k==NPL-1) {
-      snap_w  (ie,ip,jp,NPL) = w  (ie,tl,ip,jp,NPL).fastAccessDx(ider);
-      snap_phi(ie,ip,jp,NPL) = phi(ie,tl,ip,jp,NPL).fastAccessDx(ider);
-    }
+    Kokkos::MDRangePolicy<ExecSpace,Kokkos::Rank<4>> policy({0,0,0,0},{m_num_elems,NP,NP,NUM_PHYSICAL_LEV});
+    Kokkos::parallel_for(policy,copy);
   };
 
-  Kokkos::MDRangePolicy<ExecSpace,Kokkos::Rank<4>> policy({0,0,0,0},{m_num_elems,NP,NP,NUM_PHYSICAL_LEV});
-  Kokkos::parallel_for(policy,copy);
+  if constexpr (Sacado::IsFad<ST>::value) {
+    auto v   = ekat::scalarize(m_v);
+    auto vth = ekat::scalarize(m_vtheta_dp);
+    auto dp  = ekat::scalarize(m_dp3d);
+    auto w   = ekat::scalarize(m_w_i);
+    auto phi = ekat::scalarize(m_phinh_i);
+    auto ps  = ekat::scalarize(m_ps_v);
+    do_take(v,vth,dp,w,phi,ps);
+  }
 }
 #endif // HOMMEXX_ENABLE_FAD_TYPES
 

--- a/components/homme/src/theta-l_kokkos/cxx/StateSnapshot.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/StateSnapshot.cpp
@@ -1,0 +1,18 @@
+#include "StateSnapshot.hpp"
+
+namespace Homme {
+
+StateSnapshot::
+StateSnapshot(int nelem, bool alloc_ps)
+ : num_elems(nelem)
+ , v ("v",nelem)
+ , vtheta_dp ("vtheta_dp",nelem)
+ , dp3d ("dp3d",nelem)
+ , w_i ("w",nelem)
+ , phinh_i ("phinh",nelem)
+{
+  if (alloc_ps)
+    ps_v = decltype(ps_v)("ps",nelem);
+}
+
+} // namespace Homme

--- a/components/homme/src/theta-l_kokkos/cxx/StateSnapshot.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/StateSnapshot.cpp
@@ -1,5 +1,7 @@
 #include "StateSnapshot.hpp"
 
+#include "ElementsState.hpp"
+
 namespace Homme {
 
 StateSnapshot::
@@ -13,6 +15,66 @@ StateSnapshot(int nelem, bool alloc_ps)
 {
   if (alloc_ps)
     ps_v = decltype(ps_v)("ps",nelem);
+}
+
+void StateSnapshot::deep_copy (const StateSnapshot& src)
+{
+  EKAT_REQUIRE_MSG ((ps_v.data()!=nullptr)==(src.ps_v.data()!=nullptr),
+      "Error! Src and tgt StateSnapshot must agree on whether to use ps_v.\n");
+  Kokkos::deep_copy(v,src.v);
+  Kokkos::deep_copy(vtheta_dp,src.vtheta_dp);
+  Kokkos::deep_copy(dp3d,src.dp3d);
+  Kokkos::deep_copy(w_i,src.w_i);
+  Kokkos::deep_copy(phinh_i,src.phinh_i);
+
+  if (ps_v.data()!=nullptr)
+    Kokkos::deep_copy(ps_v,src.ps_v);
+}
+
+StateSnapshot StateSnapshot::clone (const bool deep_copy) const
+{
+  auto copy = StateSnapshot(num_elems,ps_v.data()!=nullptr);
+  if (deep_copy)
+    copy.deep_copy(*this);
+  return copy;
+}
+
+void StateSnapshot::randomize (const int seed, const Real p_max, const Real p0, const Real hyai0)
+{
+  constexpr auto A = Kokkos::ALL;
+
+  // Recycle ElementsStateST implementation
+  ElementsStateST<Real> st;
+  st.init(num_elems);
+  st.randomize(seed,p_max,p0,hyai0);
+
+  Kokkos::deep_copy(v,Kokkos::subview(st.m_v,A,0,A,A,A,A));
+  Kokkos::deep_copy(vtheta_dp,Kokkos::subview(st.m_vtheta_dp,A,0,A,A,A));
+  Kokkos::deep_copy(w_i,Kokkos::subview(st.m_w_i,A,0,A,A,A));
+  Kokkos::deep_copy(dp3d,Kokkos::subview(st.m_dp3d,A,0,A,A,A));
+  Kokkos::deep_copy(phinh_i,Kokkos::subview(st.m_phinh_i,A,0,A,A,A));
+  if (ps_v.data()!=nullptr)
+    Kokkos::deep_copy(ps_v,Kokkos::subview(st.m_ps_v,A,0,A,A));
+}
+
+void StateSnapshot::
+randomize (const int seed, const Real p_max, const Real p0, const Real hyai0,
+           const ExecViewUnmanaged<const Real*[NP][NP]>& phis)
+{
+  constexpr auto A = Kokkos::ALL;
+
+  // Recycle ElementsStateST implementation
+  ElementsStateST<Real> st;
+  st.init(num_elems);
+  st.randomize(seed,p_max,p0,hyai0,phis);
+
+  Kokkos::deep_copy(v,Kokkos::subview(st.m_v,A,0,A,A,A,A));
+  Kokkos::deep_copy(vtheta_dp,Kokkos::subview(st.m_vtheta_dp,A,0,A,A,A));
+  Kokkos::deep_copy(w_i,Kokkos::subview(st.m_w_i,A,0,A,A,A));
+  Kokkos::deep_copy(dp3d,Kokkos::subview(st.m_dp3d,A,0,A,A,A));
+  Kokkos::deep_copy(phinh_i,Kokkos::subview(st.m_phinh_i,A,0,A,A,A));
+  if (ps_v.data()!=nullptr)
+    Kokkos::deep_copy(ps_v,Kokkos::subview(st.m_ps_v,A,0,A,A));
 }
 
 } // namespace Homme

--- a/components/homme/src/theta-l_kokkos/cxx/StateSnapshot.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/StateSnapshot.hpp
@@ -10,6 +10,17 @@ struct StateSnapshot {
   using PT = PackType<ST>;
 
   StateSnapshot (int nelem, bool alloc_ps = false);
+  StateSnapshot (const StateSnapshot&) = default;
+
+  StateSnapshot& operator= (const StateSnapshot&) = default;
+
+  void deep_copy (const StateSnapshot& src);
+
+  StateSnapshot clone (const bool deep_copy = false) const;
+
+  void randomize (const int seed, const Real p_max, const Real p0, const Real hyai0);
+  void randomize (const int seed, const Real p_max, const Real p0, const Real hyai0,
+                  const ExecViewUnmanaged<const Real*[NP][NP]>& phis);
 
   int num_elems;
 

--- a/components/homme/src/theta-l_kokkos/cxx/StateSnapshot.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/StateSnapshot.hpp
@@ -1,0 +1,26 @@
+#ifndef HOMMEXX_STATE_SNAPSHOT_HPP
+#define HOMMEXX_STATE_SNAPSHOT_HPP
+
+#include "Types.hpp"
+
+namespace Homme {
+
+struct StateSnapshot {
+  using ST = Real;
+  using PT = PackType<ST>;
+
+  StateSnapshot (int nelem, bool alloc_ps = false);
+
+  int num_elems;
+
+  ExecViewManaged<PT * [2][NP][NP][NUM_LEV  ]> v;          // Horizontal velocity
+  ExecViewManaged<PT *    [NP][NP][NUM_LEV  ]> vtheta_dp;  // Virtual potential temperature (mass)
+  ExecViewManaged<PT *    [NP][NP][NUM_LEV  ]> dp3d;       // Delta p on levels
+  ExecViewManaged<PT *    [NP][NP][NUM_LEV_P]> w_i;        // Vertical velocity at interfaces
+  ExecViewManaged<PT *    [NP][NP][NUM_LEV_P]> phinh_i;    // Geopotential used by NH model at interfaces
+  ExecViewManaged<ST *    [NP][NP]           > ps_v;       // Surface pressure
+};
+
+} // namespace Homme
+
+#endif  // HOMMEXX_STATE_SNAPSHOT_HPP

--- a/components/homme/test_execs/thetal_kokkos_ut/CMakeLists.txt
+++ b/components/homme/test_execs/thetal_kokkos_ut/CMakeLists.txt
@@ -389,7 +389,6 @@ if (HOMMEXX_ENABLE_FAD_TYPES)
   # Eqn of state sacado derivatives tests
   EkatCreateUnitTest (eos_sacado_ut
     eos_sacado_ut.cpp
-    COMPILER_CXX_DEFS
     LIBS thetal_kokkos_ut_lib
     LABELS AMDIS
   )
@@ -397,7 +396,6 @@ if (HOMMEXX_ENABLE_FAD_TYPES)
   # Dirk sacado derivatives tests
   EkatCreateUnitTest ("dirk_sacado_ut"
     "dirk_sacado_ut.cpp;${SHARE_UT_DIR}/geometry_interface.F90;thetal_test_interface.F90"
-    COMPILER_CXX_DEFS
     LIBS thetal_kokkos_ut_lib
     LABELS AMDIS
   )

--- a/components/homme/test_execs/thetal_kokkos_ut/caar_sacado_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/caar_sacado_ut.cpp
@@ -415,12 +415,7 @@ TEST_CASE("caar_dx_check") {
         elems_dp.m_state.randomize_derivs(seed,n0);
 
         // Extract derivs into a non-fad type for the Dp = Dx*Dp_old test
-        Kokkos::deep_copy(elems.m_state.m_v,0);
-        Kokkos::deep_copy(elems.m_state.m_vtheta_dp,0);
-        Kokkos::deep_copy(elems.m_state.m_dp3d,0);
-        Kokkos::deep_copy(elems.m_state.m_phinh_i,0);
-        Kokkos::deep_copy(elems.m_state.m_w_i,0);
-        elems.m_state.import_values_from_deriv(elems_dp.m_state,n0,0);
+        auto dxdp0 = elems_dp.m_state.take_deriv_snapshot(n0,0);
 
         // Init d/dx state
         elems_dx.m_state.import_values(elems_dp.m_state,n0);
@@ -454,6 +449,7 @@ TEST_CASE("caar_dx_check") {
         // RUN caar's J*V functor for ST=DxFadType
         caar_dx.init_J(data);
         caar_dx.run_pre_exchange(data);
+        elems.m_state.import_snapshot(dxdp0,n0,0);
         caar_dx.run_JV(data,elems.m_state);
 
         // Check that dXnew/dp = dXnew/dXold * dXold/dp. dXnew/dp is in elems_dp.m_state at slice np1

--- a/components/homme/test_execs/thetal_kokkos_ut/caar_sacado_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/caar_sacado_ut.cpp
@@ -318,10 +318,9 @@ TEST_CASE("caar_dx_check") {
   const int num_elems = c.get<Connectivity>().get_num_local_elements();
   const auto max_pressure = 1000.0 + hvcoord.ps0; // This ensures max_p > ps0
 
-  // Create elements with Real scalar type
-  auto& elems = c.create<ElementsST<Real>>();
-  elems.init(num_elems,false,true,PhysicalConstants::rearth0);
-  auto& geo = elems.m_geometry;
+  // Create elements geometry
+  auto& geo = c.create<ElementsGeometry>();
+  geo.init(num_elems,false,true,PhysicalConstants::rearth0);
   geo.randomize(seed);
 
   // Create elements with DpFadType scalar type
@@ -336,7 +335,6 @@ TEST_CASE("caar_dx_check") {
 
   // Get or create and init other structures needed
   auto& bm = c.create<MpiBuffersManager>();
-  auto& sphop = c.create<SphereOperatorsST<Real>>();
   auto& sphop_dp = c.create<SphereOperatorsST<DpFadType>>();
   auto& sphop_dx = c.create<SphereOperatorsST<DxFadType>>();
   auto& tracers = c.create<TracersST<Real>>();
@@ -344,16 +342,13 @@ TEST_CASE("caar_dx_check") {
   auto& tracers_dx = c.create<TracersST<DxFadType>>();
 
   // The Caar functor also runs the limiter functor (bad design, imho)
-  auto& limiter = c.create<LimiterFunctorST<Real>>(elems,hvcoord,params);
   auto& limiter_dp = c.create<LimiterFunctorST<DpFadType>>(elems_dp,hvcoord,params);
   auto& limiter_dx = c.create<LimiterFunctorST<DxFadType>>(elems_dx,hvcoord,params);
-  limiter.m_verbose = false;
   limiter_dp.m_verbose = false;
   limiter_dx.m_verbose = false;
 
   sphop_dx.setup(geo,ref_FE);
   sphop_dp.setup(geo,ref_FE);
-  sphop.setup(geo,ref_FE);
   if (!bm.is_connectivity_set ()) {
     bm.set_connectivity(c.get_ptr<Connectivity>());
   }
@@ -371,8 +366,8 @@ TEST_CASE("caar_dx_check") {
       std::cout << " -> " << (hydrostatic ? "Hydrostatic\n" : "Non-Hydrostatic\n");
     }
     params.theta_hydrostatic_mode = hydrostatic;
-    limiter.m_theta_hydrostatic_mode = hydrostatic;
     limiter_dp.m_theta_hydrostatic_mode = hydrostatic;
+    limiter_dx.m_theta_hydrostatic_mode = hydrostatic;
     auto adv_forms = {AdvectionForm::Conservative, AdvectionForm::NonConservative};
     for (const AdvectionForm adv_form : adv_forms) {
       if (comm.am_i_root()) {
@@ -449,8 +444,9 @@ TEST_CASE("caar_dx_check") {
         // RUN caar's J*V functor for ST=DxFadType
         caar_dx.init_J(data);
         caar_dx.run_pre_exchange(data);
-        elems.m_state.import_snapshot(dxdp0,n0,0);
-        caar_dx.run_JV(data,elems.m_state);
+        auto x = dxdp0.clone(true);
+        auto y = x.clone();
+        caar_dx.run_JV(data,x,y);
 
         // Check that dXnew/dp = dXnew/dXold * dXold/dp. dXnew/dp is in elems_dp.m_state at slice np1
         // while dXnew/dXold is in elems_dx.m_state at slice np1
@@ -471,11 +467,11 @@ TEST_CASE("caar_dx_check") {
         Kokkos::deep_copy(phi_dp_h, phi_dp);
         Kokkos::deep_copy(w_dp_h,   w_dp);
 
-        auto v_JV   = ekat::scalarize(elems.m_state.m_v);
-        auto vth_JV = ekat::scalarize(elems.m_state.m_vtheta_dp);
-        auto dp_JV  = ekat::scalarize(elems.m_state.m_dp3d);
-        auto phi_JV = ekat::scalarize(elems.m_state.m_phinh_i);
-        auto w_JV   = ekat::scalarize(elems.m_state.m_w_i);
+        auto v_JV   = ekat::scalarize(y.v);
+        auto vth_JV = ekat::scalarize(y.vtheta_dp);
+        auto dp_JV  = ekat::scalarize(y.dp3d);
+        auto phi_JV = ekat::scalarize(y.phinh_i);
+        auto w_JV   = ekat::scalarize(y.w_i);
         auto v_JV_h   = Kokkos::create_mirror_view(v_JV);
         auto vth_JV_h = Kokkos::create_mirror_view(vth_JV);
         auto dp_JV_h  = Kokkos::create_mirror_view(dp_JV);
@@ -491,30 +487,30 @@ TEST_CASE("caar_dx_check") {
           for (int igp=0; igp<NP; ++igp) {
             for (int jgp=0; jgp<NP; ++jgp) {
               for (int k=0; k<NUM_PHYSICAL_LEV; ++k) {
-                auto du_src = v_JV_h(ie,np1,0,igp,jgp,k), du_tgt = v_dp_h(ie,np1,0,igp,jgp,k).dx(0);
+                auto du_src = v_JV_h(ie,0,igp,jgp,k), du_tgt = v_dp_h(ie,np1,0,igp,jgp,k).dx(0);
                 CHECK_THAT (du_src, Catch::WithinRel(du_tgt,rtol) || Catch::WithinAbs(du_tgt,atol));
 
-                auto dv_src = v_JV_h(ie,np1,1,igp,jgp,k), dv_tgt = v_dp_h(ie,np1,1,igp,jgp,k).dx(0);
+                auto dv_src = v_JV_h(ie,1,igp,jgp,k), dv_tgt = v_dp_h(ie,np1,1,igp,jgp,k).dx(0);
                 CHECK_THAT (dv_src, Catch::WithinRel(dv_tgt,rtol) || Catch::WithinAbs(dv_tgt,atol));
 
-                auto dvth_src = vth_JV_h(ie,np1,igp,jgp,k), dvth_tgt = vth_dp_h(ie,np1,igp,jgp,k).dx(0);
+                auto dvth_src = vth_JV_h(ie,igp,jgp,k), dvth_tgt = vth_dp_h(ie,np1,igp,jgp,k).dx(0);
                 CHECK_THAT (dvth_src, Catch::WithinRel(dvth_tgt,rtol) || Catch::WithinAbs(dvth_tgt,atol));
 
-                auto ddp_src = dp_JV_h(ie,np1,igp,jgp,k), ddp_tgt = dp_dp_h(ie,np1,igp,jgp,k).dx(0);
+                auto ddp_src = dp_JV_h(ie,igp,jgp,k), ddp_tgt = dp_dp_h(ie,np1,igp,jgp,k).dx(0);
                 CHECK_THAT (ddp_src, Catch::WithinRel(ddp_tgt,rtol) || Catch::WithinAbs(ddp_tgt,atol));
 
-                auto dphi_src = phi_JV_h(ie,np1,igp,jgp,k), dphi_tgt = phi_dp_h(ie,np1,igp,jgp,k).dx(0);
+                auto dphi_src = phi_JV_h(ie,igp,jgp,k), dphi_tgt = phi_dp_h(ie,np1,igp,jgp,k).dx(0);
                 CHECK_THAT (dphi_src, Catch::WithinRel(dphi_tgt,rtol) || Catch::WithinAbs(dphi_tgt,atol));
 
-                auto dw_src = w_JV_h(ie,np1,igp,jgp,k), dw_tgt = w_dp_h(ie,np1,igp,jgp,k).dx(0);
+                auto dw_src = w_JV_h(ie,igp,jgp,k), dw_tgt = w_dp_h(ie,np1,igp,jgp,k).dx(0);
                 CHECK_THAT (dw_src, Catch::WithinRel(dw_tgt,rtol) || Catch::WithinAbs(dw_tgt,atol));
               }
               int k = NUM_PHYSICAL_LEV;
 
-              auto dphi_src = phi_JV_h(ie,np1,igp,jgp,k), dphi_tgt = phi_dp_h(ie,np1,igp,jgp,k).dx(0);
+              auto dphi_src = phi_JV_h(ie,igp,jgp,k), dphi_tgt = phi_dp_h(ie,np1,igp,jgp,k).dx(0);
               CHECK_THAT (dphi_src, Catch::WithinRel(dphi_tgt,rtol) || Catch::WithinAbs(dphi_tgt,atol));
 
-              auto dw_src = w_JV_h(ie,np1,igp,jgp,k), dw_tgt = w_dp_h(ie,np1,igp,jgp,k).dx(0);
+              auto dw_src = w_JV_h(ie,igp,jgp,k), dw_tgt = w_dp_h(ie,np1,igp,jgp,k).dx(0);
               CHECK_THAT (dw_src, Catch::WithinRel(dw_tgt,rtol) || Catch::WithinAbs(dw_tgt,atol));
             }
           }
@@ -612,23 +608,32 @@ TEST_CASE("caar_jtv_check") {
 
   const int nm1 = 0, n0 = 1, np1 = 2;
 
-  // Two adjoint vectors, created independently of the Context.
-  ElementsStateST<Real> adj_a, adj_b;
-  adj_a.init(num_elems);
-  adj_b.init(num_elems);
+  StateSnapshot xa(num_elems), xb(num_elems), ya(num_elems), yb(num_elems);
 
   // Scalarized device views (share memory with the packed views above).
-  auto sa_v   = ekat::scalarize(adj_a.m_v);
-  auto sa_vth = ekat::scalarize(adj_a.m_vtheta_dp);
-  auto sa_dp  = ekat::scalarize(adj_a.m_dp3d);
-  auto sa_phi = ekat::scalarize(adj_a.m_phinh_i);
-  auto sa_w   = ekat::scalarize(adj_a.m_w_i);
+  auto sxa_v   = ekat::scalarize(xa.v);
+  auto sxa_vth = ekat::scalarize(xa.vtheta_dp);
+  auto sxa_dp  = ekat::scalarize(xa.dp3d);
+  auto sxa_phi = ekat::scalarize(xa.phinh_i);
+  auto sxa_w   = ekat::scalarize(xa.w_i);
 
-  auto sb_v   = ekat::scalarize(adj_b.m_v);
-  auto sb_vth = ekat::scalarize(adj_b.m_vtheta_dp);
-  auto sb_dp  = ekat::scalarize(adj_b.m_dp3d);
-  auto sb_phi = ekat::scalarize(adj_b.m_phinh_i);
-  auto sb_w   = ekat::scalarize(adj_b.m_w_i);
+  auto sxb_v   = ekat::scalarize(xb.v);
+  auto sxb_vth = ekat::scalarize(xb.vtheta_dp);
+  auto sxb_dp  = ekat::scalarize(xb.dp3d);
+  auto sxb_phi = ekat::scalarize(xb.phinh_i);
+  auto sxb_w   = ekat::scalarize(xb.w_i);
+
+  auto sya_v   = ekat::scalarize(ya.v);
+  auto sya_vth = ekat::scalarize(ya.vtheta_dp);
+  auto sya_dp  = ekat::scalarize(ya.dp3d);
+  auto sya_phi = ekat::scalarize(ya.phinh_i);
+  auto sya_w   = ekat::scalarize(ya.w_i);
+
+  auto syb_v   = ekat::scalarize(yb.v);
+  auto syb_vth = ekat::scalarize(yb.vtheta_dp);
+  auto syb_dp  = ekat::scalarize(yb.dp3d);
+  auto syb_phi = ekat::scalarize(yb.phinh_i);
+  auto syb_w   = ekat::scalarize(yb.w_i);
 
   using p4_mid_t = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>;
   using p5_mid_t = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>>;
@@ -689,9 +694,8 @@ TEST_CASE("caar_jtv_check") {
         caar_dx.init_boundary_exchanges(c.get_ptr<MpiBuffersManager>());
 
         // Randomize adj_state a and b (make them equal);
-        adj_a.randomize(seed, max_pressure, hvcoord.ps0, hvcoord.hybrid_ai0, geo.m_phis);
-        adj_b.import_values(adj_a,n0);
-        adj_b.import_values(adj_a,nm1);
+        xa.randomize(seed, max_pressure, hvcoord.ps0, hvcoord.hybrid_ai0, geo.m_phis);
+        xb.randomize(seed, max_pressure, hvcoord.ps0, hvcoord.hybrid_ai0, geo.m_phis);
 
         // Init d/dx(n0) structures
         caar_dx.init_J(data);
@@ -700,40 +704,40 @@ TEST_CASE("caar_jtv_check") {
         caar_dx.run_pre_exchange(data);
 
         // J*b   -> adj_b[np1]
-        caar_dx.run_JV(data, adj_b);
+        caar_dx.run_JV(data, xb, yb);
         // J^T*a -> adj_a[np1]
-        caar_dx.run_JtV(data, adj_a);
+        caar_dx.run_JtV(data, xa, ya);
 
-        // dot1 = <a[n0], (J*b)[np1]>
-        // dot2 = <(J^T*a)[np1], b[n0]>
+        // (xa,yb) = (xa,J*xb) = (J^T*xa,xb) = (ya,xb)
         // Note: we must sum over all state vars, since J and J^T scramble them differently
+        //       The contributions of each vars are kept just for debugging weird vals (like nans)
         Real2 V_dot, vth_dot, dp_dot, phi_dot, w_dot;
         Real2 gdot;
 
         Kokkos::parallel_reduce(p5_mid,
           KOKKOS_LAMBDA(int ie, int icmp, int ip, int jp, int k, Real2& acc) {
-            acc.v[0] += sa_v(ie, n0,  icmp, ip, jp, k) * sb_v(ie, np1, icmp, ip, jp, k);
-            acc.v[1] += sa_v(ie, np1, icmp,  ip, jp, k) * sb_v(ie, n0, icmp,  ip, jp, k);
+            acc.v[0] += sxa_v(ie, icmp, ip, jp, k) * syb_v(ie, icmp, ip, jp, k);
+            acc.v[1] += sya_v(ie, icmp,  ip, jp, k) * sxb_v(ie,icmp,  ip, jp, k);
           }, V_dot);
         Kokkos::parallel_reduce(p4_mid,
           KOKKOS_LAMBDA(int ie, int ip, int jp, int k, Real2& acc) {
-            acc.v[0] += sa_vth(ie, n0,  ip, jp, k) * sb_vth(ie, np1, ip, jp, k);
-            acc.v[1] += sa_vth(ie, np1, ip, jp, k) * sb_vth(ie, n0,  ip, jp, k);
+            acc.v[0] += sxa_vth(ie, ip, jp, k) * syb_vth(ie, ip, jp, k);
+            acc.v[1] += sya_vth(ie, ip, jp, k) * sxb_vth(ie, ip, jp, k);
           }, vth_dot);
         Kokkos::parallel_reduce(p4_mid,
           KOKKOS_LAMBDA(int ie, int ip, int jp, int k, Real2& acc) {
-            acc.v[0] += sa_dp(ie, n0,  ip, jp, k) * sb_dp(ie, np1, ip, jp, k);
-            acc.v[1] += sa_dp(ie, np1, ip, jp, k) * sb_dp(ie, n0,  ip, jp, k);
+            acc.v[0] += sxa_dp(ie, ip, jp, k) * syb_dp(ie, ip, jp, k);
+            acc.v[1] += sya_dp(ie, ip, jp, k) * sxb_dp(ie, ip, jp, k);
           }, dp_dot);
         Kokkos::parallel_reduce(p4_int,
           KOKKOS_LAMBDA(int ie, int ip, int jp, int k, Real2& acc) {
-            acc.v[0] += sa_phi(ie, n0,  ip, jp, k) * sb_phi(ie, np1, ip, jp, k);
-            acc.v[1] += sa_phi(ie, np1, ip, jp, k) * sb_phi(ie, n0,  ip, jp, k);
+            acc.v[0] += sxa_phi(ie, ip, jp, k) * syb_phi(ie, ip, jp, k);
+            acc.v[1] += sya_phi(ie, ip, jp, k) * sxb_phi(ie, ip, jp, k);
           }, phi_dot);
         Kokkos::parallel_reduce(p4_int,
           KOKKOS_LAMBDA(int ie, int ip, int jp, int k, Real2& acc) {
-            acc.v[0] += sa_w(ie, n0,  ip, jp, k) * sb_w(ie, np1, ip, jp, k);
-            acc.v[1] += sa_w(ie, np1, ip, jp, k) * sb_w(ie, n0,  ip, jp, k);
+            acc.v[0] += sxa_w(ie, ip, jp, k) * syb_w(ie, ip, jp, k);
+            acc.v[1] += sya_w(ie, ip, jp, k) * sxb_w(ie, ip, jp, k);
           }, w_dot);
 
         gdot += V_dot;

--- a/components/homme/test_execs/thetal_kokkos_ut/dirk_sacado_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/dirk_sacado_ut.cpp
@@ -210,7 +210,9 @@ TEST_CASE ("dirk_jv_testing") {
   // Verify the chain rule: dX_np1/dp = J * (dX_n0/dp)
   //  - LHS: computed via DpFadType by running DIRK with FAD arithmetic over p
   //  - RHS: computed via init_J + run + run_JV (DxFadTypeDirk)
-  // This checks that J = d(state_np1) / d(state_n0) is correctly assembled.
+  // NOTE: here, X_np1 and X_n0 refer to the state before and after running DIRK.
+  // In terms of time slices, they both refer to np1, since DIRK updates that
+  // slice in place.
 
   std::random_device rd;
   const unsigned int catchRngSeed = Catch::rngSeed();
@@ -243,29 +245,19 @@ TEST_CASE ("dirk_jv_testing") {
   using DirkDp = DirkFunctorImplST<DpFadType>;
   using DirkDx = DirkFunctorImplST<DxFadType>;
 
-  // elems:    Real-typed, holds V = dX_n0/dp and after run_JV holds J*V at np1
   // elems_dp: DpFadType, used to compute dX_np1/dp directly via FAD DIRK run
   // elems_dx: DxFadTypeDirk, used to compute J via init_J + run
-  ElementsST<Real>      elems;
   ElementsST<DpFadType> elems_dp;
   ElementsST<DxFadType> elems_dx;
-  elems.init(num_elems, false, true, PhysicalConstants::rearth0, -1, true);
   elems_dp.init(num_elems, false, true, PhysicalConstants::rearth0, -1, true);
   elems_dx.init(num_elems, false, true, PhysicalConstants::rearth0, -1, true);
 
-  auto& geometry = elems.m_geometry = elems_dp.m_geometry = elems_dx.m_geometry;
-  Context::singleton().create_ref(elems.m_geometry);
+  auto& geometry = elems_dp.m_geometry = elems_dx.m_geometry;
+  Context::singleton().create_ref(geometry);
   geometry.randomize(seed);
 
   // Randomize state values (real part) for all time levels
   elems_dp.m_state.randomize(seed, max_pressure, hvcoord.ps0, hvcoord.hybrid_ai0, geometry.m_phis);
-
-  // Randomize FAD derivatives at n0: these represent dX_n0/dp for a random scalar p
-  elems_dp.m_state.randomize_derivs(seed, n0);
-
-  // Initialize DxFadType state with the same real values as DpFadType state
-  for (int tl = 0; tl < NUM_TIME_LEVELS; ++tl)
-    elems_dx.m_state.import_values(elems_dp.m_state, tl);
 
   // Create DIRK functors
   DirkDp dirk_dp(num_elems);
@@ -283,17 +275,22 @@ TEST_CASE ("dirk_jv_testing") {
   const Real dt2 = rpdf(0.1, 0.9)(engine);
   const bool bfb_solver = false;
 
-  // Extract V = dX_n0/dp into the Real element state at n0
-  auto dxdp0 = elems_dp.m_state.take_deriv_snapshot(n0,0);
-
+  StateSnapshot x(num_elems), y(num_elems);
   for (Real alphadt_nm1 : {0.0, 0.3}) {
-    const int nm1_tl = (alphadt_nm1 == 0.0) ? -1 : nm1;
     printf("-> alphadt_nm1: %f\n", alphadt_nm1);
     for (Real alphadt_n0 : {0.0, 0.7}) {
       printf("  -> alphadt_n0: %f\n", alphadt_n0);
 
+      // Set dx state VALUES to match the dp state ones
+      for (int tl = 0; tl < NUM_TIME_LEVELS; ++tl)
+        elems_dx.m_state.import_values(elems_dp.m_state, tl);
+
+      // Randomize initial sensitivities, and store them (for JV step)
+      elems_dp.m_state.randomize_derivs(seed, np1);
+      elems_dp.m_state.take_deriv_snapshot(x,np1,0);
+
       // Step 1: run DpFadType DIRK to compute dX_np1/dp
-      dirk_dp.run(nm1_tl, alphadt_nm1, n0, alphadt_n0, np1, dt2,
+      dirk_dp.run(nm1, alphadt_nm1, n0, alphadt_n0, np1, dt2,
                   elems_dp, hvcoord, bfb_solver);
       Kokkos::fence();
 
@@ -301,20 +298,19 @@ TEST_CASE ("dirk_jv_testing") {
       //   init_J  - set d(X_n0[k])/d(X_n0[k]) = 1 per state variable per level k per column
       //   run     - Newton solve with FAD arithmetic, propagating J through the solve
       //   run_JV  - apply product rule: (J at np1) * (V at n0) -> result at np1
-      dirk_dx.init_J(n0, elems_dx);
-      dirk_dx.run(nm1_tl, alphadt_nm1, n0, alphadt_n0, np1, dt2,
+      dirk_dx.init_J(np1, elems_dx.m_state);
+      dirk_dx.run(nm1, alphadt_nm1, n0, alphadt_n0, np1, dt2,
                   elems_dx, hvcoord, bfb_solver);
       Kokkos::fence();
-      elems.m_state.import_snapshot(dxdp0,n0);
-      dirk_dx.run_JV(n0, np1, elems_dx, elems.m_state);
+      dirk_dx.run_JV(np1, elems_dx.m_state, x, y);
       Kokkos::fence();
 
       // Compare: elems.m_state at np1 (= J*V) vs. elems_dp.m_state.dx(0) at np1 (= dX_np1/dp)
       // DIRK only updates w_i and phinh_i; check both interface-level fields.
       auto dphi_dp = ekat::scalarize(elems_dp.m_state.m_phinh_i);
       auto dw_dp   = ekat::scalarize(elems_dp.m_state.m_w_i);
-      auto dphi_jv = ekat::scalarize(elems.m_state.m_phinh_i);
-      auto dw_jv   = ekat::scalarize(elems.m_state.m_w_i);
+      auto dphi_jv = ekat::scalarize(y.phinh_i);
+      auto dw_jv   = ekat::scalarize(y.w_i);
 
       const auto dphi_dp_h = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), dphi_dp);
       const auto dw_dp_h   = Kokkos::create_mirror_view_and_copy(Kokkos::HostSpace(), dw_dp);
@@ -325,11 +321,11 @@ TEST_CASE ("dirk_jv_testing") {
         for (int ip = 0; ip < np; ++ip)
           for (int jp = 0; jp < np; ++jp)
             for (int k = 0; k <= nlev; ++k) {
-              auto dphi_src = dphi_jv_h(ie, np1, ip, jp, k);
+              auto dphi_src = dphi_jv_h(ie, ip, jp, k);
               auto dphi_tgt = dphi_dp_h(ie, np1, ip, jp, k).dx(0);
               CHECK_THAT(dphi_src, Catch::WithinRel(dphi_tgt, rtol) || Catch::WithinAbs(dphi_tgt, atol));
 
-              auto dw_src = dw_jv_h(ie, np1, ip, jp, k);
+              auto dw_src = dw_jv_h(ie, ip, jp, k);
               auto dw_tgt = dw_dp_h(ie, np1, ip, jp, k).dx(0);
               CHECK_THAT(dw_src, Catch::WithinRel(dw_tgt, rtol) || Catch::WithinAbs(dw_tgt, atol));
             }
@@ -347,7 +343,7 @@ TEST_CASE ("dirk_jtv_testing") {
 
   std::random_device rd;
   const unsigned int catchRngSeed = Catch::rngSeed();
-  const unsigned int seed = catchRngSeed == 0 ? rd() : catchRngSeed;
+  unsigned int seed = catchRngSeed == 0 ? rd() : catchRngSeed;
   std::cout << "seed: " << seed << (catchRngSeed == 0 ? " (catch rng seed was 0)\n" : "\n");
 
   using ipdf = std::uniform_int_distribution<int>;
@@ -367,7 +363,7 @@ TEST_CASE ("dirk_jtv_testing") {
   int np1 = 2;
 
   HybridVCoord hvcoord;
-  hvcoord.random_init(seed);
+  hvcoord.random_init(seed++);
   const auto max_pressure = 1000 + hvcoord.ps0;
 
   using DxFadType = DxFadTypeDirk;
@@ -378,15 +374,16 @@ TEST_CASE ("dirk_jtv_testing") {
 
   auto& geometry = elems_dx.m_geometry;
   Context::singleton().create_ref(geometry);
-  geometry.randomize(seed);
+  geometry.randomize(seed++);
 
   // Two adjoint vectors (Real), both initialized to the same random state at n0.
   // run_JV / run_JtV only read n0 and write np1, so n0 remains unchanged throughout.
-  ElementsStateST<Real> adj_a, adj_b;
-  adj_a.init(num_elems);
-  adj_b.init(num_elems);
-  adj_a.randomize(seed + 1, max_pressure, hvcoord.ps0, hvcoord.hybrid_ai0, geometry.m_phis);
-  adj_b.import_values(adj_a, n0);
+  StateSnapshot xa(num_elems), xb(num_elems);
+  xa.randomize(seed++, max_pressure, hvcoord.ps0, hvcoord.hybrid_ai0, geometry.m_phis);
+  xb.randomize(seed++, max_pressure, hvcoord.ps0, hvcoord.hybrid_ai0, geometry.m_phis);
+
+  auto ya = xa.clone();
+  auto yb = xb.clone();
 
   DirkDx dirk_dx(num_elems);
   dirk_dx.m_verbose = false;
@@ -406,20 +403,31 @@ TEST_CASE ("dirk_jtv_testing") {
   const p5_mid_t p5_mid({0,0,0,0,0}, {num_elems, 2, NP, NP, NUM_PHYSICAL_LEV});
   const p4_int_t p4_int({0,0,0,0}, {num_elems, NP, NP, NUM_INTERFACE_LEV});
 
-  auto sa_v   = ekat::scalarize(adj_a.m_v);
-  auto sa_vth = ekat::scalarize(adj_a.m_vtheta_dp);
-  auto sa_dp  = ekat::scalarize(adj_a.m_dp3d);
-  auto sa_phi = ekat::scalarize(adj_a.m_phinh_i);
-  auto sa_w   = ekat::scalarize(adj_a.m_w_i);
+  auto xa_v   = ekat::scalarize(xa.v);
+  auto xa_vth = ekat::scalarize(xa.vtheta_dp);
+  auto xa_dp  = ekat::scalarize(xa.dp3d);
+  auto xa_phi = ekat::scalarize(xa.phinh_i);
+  auto xa_w   = ekat::scalarize(xa.w_i);
 
-  auto sb_v   = ekat::scalarize(adj_b.m_v);
-  auto sb_vth = ekat::scalarize(adj_b.m_vtheta_dp);
-  auto sb_dp  = ekat::scalarize(adj_b.m_dp3d);
-  auto sb_phi = ekat::scalarize(adj_b.m_phinh_i);
-  auto sb_w   = ekat::scalarize(adj_b.m_w_i);
+  auto ya_v   = ekat::scalarize(ya.v);
+  auto ya_vth = ekat::scalarize(ya.vtheta_dp);
+  auto ya_dp  = ekat::scalarize(ya.dp3d);
+  auto ya_phi = ekat::scalarize(ya.phinh_i);
+  auto ya_w   = ekat::scalarize(ya.w_i);
+
+  auto xb_v   = ekat::scalarize(xb.v);
+  auto xb_vth = ekat::scalarize(xb.vtheta_dp);
+  auto xb_dp  = ekat::scalarize(xb.dp3d);
+  auto xb_phi = ekat::scalarize(xb.phinh_i);
+  auto xb_w   = ekat::scalarize(xb.w_i);
+
+  auto yb_v   = ekat::scalarize(yb.v);
+  auto yb_vth = ekat::scalarize(yb.vtheta_dp);
+  auto yb_dp  = ekat::scalarize(yb.dp3d);
+  auto yb_phi = ekat::scalarize(yb.phinh_i);
+  auto yb_w   = ekat::scalarize(yb.w_i);
 
   for (Real alphadt_nm1 : {0.0, 0.3}) {
-    const int nm1_tl = (alphadt_nm1 == 0.0) ? -1 : nm1;
     printf("-> alphadt_nm1: %f\n", alphadt_nm1);
     for (Real alphadt_n0 : {0.0, 0.7}) {
       printf("  -> alphadt_n0: %f\n", alphadt_n0);
@@ -427,46 +435,45 @@ TEST_CASE ("dirk_jtv_testing") {
       // Randomize the DxFad state for this run
       elems_dx.m_state.randomize(seed, max_pressure, hvcoord.ps0, hvcoord.hybrid_ai0, geometry.m_phis);
 
-      // Initialize Jacobian d/dx(n0) and run DIRK with FAD arithmetic
-      dirk_dx.init_J(n0, elems_dx);
-      dirk_dx.run(nm1_tl, alphadt_nm1, n0, alphadt_n0, np1, dt2, elems_dx, hvcoord, bfb_solver);
+      // Initialize Jacobian d/dx(np1) and run DIRK with FAD arithmetic
+      dirk_dx.init_J(np1, elems_dx.m_state);
+      dirk_dx.run(nm1, alphadt_nm1, n0, alphadt_n0, np1, dt2, elems_dx, hvcoord, bfb_solver);
       Kokkos::fence();
 
       // J*b  -> adj_b[np1]
-      dirk_dx.run_JV (n0, np1, elems_dx, adj_b);
+      dirk_dx.run_JV (np1, elems_dx.m_state, xa, ya);
       // J^T*a -> adj_a[np1]
-      dirk_dx.run_JtV(n0, np1, elems_dx, adj_a);
+      dirk_dx.run_JtV(np1, elems_dx.m_state, xb, yb);
       Kokkos::fence();
 
-      // Compute dot1 = <a[n0], J*b[np1]>  and  dot2 = <J^T*a[np1], b[n0]>.
-      // Both must equal a^T * J * b by the definition of the matrix transpose.
+      // (x_b,y_a) = (x_b,J*x_a) = (J^T*x_b,x_a) = (y_b,x_a)
       Real2 V_dot, vth_dot, dp_dot, phi_dot, w_dot;
       Real2 gdot;
 
       Kokkos::parallel_reduce(p5_mid,
         KOKKOS_LAMBDA(int ie, int icmp, int ip, int jp, int k, Real2& acc) {
-          acc.v[0] += sa_v(ie, n0,  icmp, ip, jp, k) * sb_v(ie, np1, icmp, ip, jp, k);
-          acc.v[1] += sa_v(ie, np1, icmp, ip, jp, k) * sb_v(ie, n0,  icmp, ip, jp, k);
+          acc.v[0] += xa_v(ie, icmp, ip, jp, k) * yb_v(ie, icmp, ip, jp, k);
+          acc.v[1] += ya_v(ie, icmp, ip, jp, k) * xb_v(ie, icmp, ip, jp, k);
         }, V_dot);
       Kokkos::parallel_reduce(p4_mid,
         KOKKOS_LAMBDA(int ie, int ip, int jp, int k, Real2& acc) {
-          acc.v[0] += sa_vth(ie, n0,  ip, jp, k) * sb_vth(ie, np1, ip, jp, k);
-          acc.v[1] += sa_vth(ie, np1, ip, jp, k) * sb_vth(ie, n0,  ip, jp, k);
+          acc.v[0] += xa_vth(ie, ip, jp, k) * yb_vth(ie, ip, jp, k);
+          acc.v[1] += ya_vth(ie, ip, jp, k) * xb_vth(ie, ip, jp, k);
         }, vth_dot);
       Kokkos::parallel_reduce(p4_mid,
         KOKKOS_LAMBDA(int ie, int ip, int jp, int k, Real2& acc) {
-          acc.v[0] += sa_dp(ie, n0,  ip, jp, k) * sb_dp(ie, np1, ip, jp, k);
-          acc.v[1] += sa_dp(ie, np1, ip, jp, k) * sb_dp(ie, n0,  ip, jp, k);
+          acc.v[0] += xa_dp(ie, ip, jp, k) * yb_dp(ie, ip, jp, k);
+          acc.v[1] += ya_dp(ie, ip, jp, k) * xb_dp(ie, ip, jp, k);
         }, dp_dot);
       Kokkos::parallel_reduce(p4_int,
         KOKKOS_LAMBDA(int ie, int ip, int jp, int k, Real2& acc) {
-          acc.v[0] += sa_phi(ie, n0,  ip, jp, k) * sb_phi(ie, np1, ip, jp, k);
-          acc.v[1] += sa_phi(ie, np1, ip, jp, k) * sb_phi(ie, n0,  ip, jp, k);
+          acc.v[0] += xa_phi(ie, ip, jp, k) * yb_phi(ie, ip, jp, k);
+          acc.v[1] += ya_phi(ie, ip, jp, k) * xb_phi(ie, ip, jp, k);
         }, phi_dot);
       Kokkos::parallel_reduce(p4_int,
         KOKKOS_LAMBDA(int ie, int ip, int jp, int k, Real2& acc) {
-          acc.v[0] += sa_w(ie, n0,  ip, jp, k) * sb_w(ie, np1, ip, jp, k);
-          acc.v[1] += sa_w(ie, np1, ip, jp, k) * sb_w(ie, n0,  ip, jp, k);
+          acc.v[0] += xa_w(ie, ip, jp, k) * yb_w(ie, ip, jp, k);
+          acc.v[1] += ya_w(ie, ip, jp, k) * xb_w(ie, ip, jp, k);
         }, w_dot);
 
       gdot += V_dot;

--- a/components/homme/test_execs/thetal_kokkos_ut/dirk_sacado_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/dirk_sacado_ut.cpp
@@ -263,14 +263,6 @@ TEST_CASE ("dirk_jv_testing") {
   // Randomize FAD derivatives at n0: these represent dX_n0/dp for a random scalar p
   elems_dp.m_state.randomize_derivs(seed, n0);
 
-  // Extract V = dX_n0/dp into the Real element state at n0
-  Kokkos::deep_copy(elems.m_state.m_v,         0);
-  Kokkos::deep_copy(elems.m_state.m_vtheta_dp, 0);
-  Kokkos::deep_copy(elems.m_state.m_dp3d,      0);
-  Kokkos::deep_copy(elems.m_state.m_phinh_i,   0);
-  Kokkos::deep_copy(elems.m_state.m_w_i,       0);
-  elems.m_state.import_values_from_deriv(elems_dp.m_state, n0, 0);
-
   // Initialize DxFadType state with the same real values as DpFadType state
   for (int tl = 0; tl < NUM_TIME_LEVELS; ++tl)
     elems_dx.m_state.import_values(elems_dp.m_state, tl);
@@ -291,6 +283,9 @@ TEST_CASE ("dirk_jv_testing") {
   const Real dt2 = rpdf(0.1, 0.9)(engine);
   const bool bfb_solver = false;
 
+  // Extract V = dX_n0/dp into the Real element state at n0
+  auto dxdp0 = elems_dp.m_state.take_deriv_snapshot(n0,0);
+
   for (Real alphadt_nm1 : {0.0, 0.3}) {
     const int nm1_tl = (alphadt_nm1 == 0.0) ? -1 : nm1;
     printf("-> alphadt_nm1: %f\n", alphadt_nm1);
@@ -310,6 +305,7 @@ TEST_CASE ("dirk_jv_testing") {
       dirk_dx.run(nm1_tl, alphadt_nm1, n0, alphadt_n0, np1, dt2,
                   elems_dx, hvcoord, bfb_solver);
       Kokkos::fence();
+      elems.m_state.import_snapshot(dxdp0,n0);
       dirk_dx.run_JV(n0, np1, elems_dx, elems.m_state);
       Kokkos::fence();
 

--- a/components/homme/test_execs/thetal_kokkos_ut/state_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/state_ut.cpp
@@ -33,13 +33,13 @@ TEST_CASE("state_tests")
   constexpr int num_elems = 4;
   constexpr auto A = Kokkos::ALL();
 
-  SECTION ("export") {
+  SECTION ("take_snapshot") {
     ElementsStateST<Real> state;
     state.init(num_elems);
     state.randomize(seed);
 
-    auto slice0 = state.export_values(0,false);
-    auto slice1 = state.export_values(1,true);
+    auto slice0 = state.take_snapshot(0,false);
+    auto slice1 = state.take_snapshot(1,true);
 
     REQUIRE (slice0.ps_v.data()==nullptr);
     REQUIRE (slice1.ps_v.data()!=nullptr);
@@ -55,27 +55,25 @@ TEST_CASE("state_tests")
   }
 
 #ifdef HOMMEXX_ENABLE_FAD_TYPES
-  SECTION ("import_from_deriv") {
+  SECTION ("take_deriv_snapshot") {
     using FadT = SFadN<Real,2>;
-    ElementsStateST<Real> state_real;
-    state_real.init(num_elems);
 
     ElementsStateST<FadT> state_fad;
     state_fad.init(num_elems);
     
     int tl =2;
     int ider = 1;
-    state_real.import_values_from_deriv (state_fad,tl,ider);
-    auto vrh = Kokkos::create_mirror_view(ekat::scalarize(state_real.m_v));
+    auto snap = state_fad.take_deriv_snapshot (tl,ider);
+    auto vrh = Kokkos::create_mirror_view(ekat::scalarize(snap.v));
     auto vfh = Kokkos::create_mirror_view(ekat::scalarize(state_fad.m_v));
-    Kokkos::deep_copy(vrh,ekat::scalarize(state_real.m_v));
+    Kokkos::deep_copy(vrh,ekat::scalarize(snap.v));
     Kokkos::deep_copy(vfh,ekat::scalarize(state_fad.m_v));
     for (int ie=0; ie<num_elems; ++ie)
       for (int ip=0; ip<NP; ++ip)
         for (int jp=0; jp<NP; ++jp)
           for (int k=0; k<NUM_PHYSICAL_LEV; ++k) {
-            REQUIRE (vrh(ie,tl,0,ip,jp,k)==vfh(ie,tl,0,ip,jp,k).fastAccessDx(ider));
-            REQUIRE (vrh(ie,tl,1,ip,jp,k)==vfh(ie,tl,1,ip,jp,k).fastAccessDx(ider));
+            REQUIRE (vrh(ie,0,ip,jp,k)==vfh(ie,tl,0,ip,jp,k).fastAccessDx(ider));
+            REQUIRE (vrh(ie,1,ip,jp,k)==vfh(ie,tl,1,ip,jp,k).fastAccessDx(ider));
           }
   }
 #endif


### PR DESCRIPTION
The methods used to require an `ElementsStateST` structure, but in the adjoint formulation, we will not use the same number of time levels for the state. Operating at the single state snapshot level is easier, as it also removes the need to know which is the correct state slice to use.