### PR TITLE
Add unit test for the the adjoint of the whole CAAR functor

### DIFF
--- a/components/homme/src/share/cxx/CaarFunctor.hpp
+++ b/components/homme/src/share/cxx/CaarFunctor.hpp
@@ -43,6 +43,12 @@ public:
   void setup(const ElementsST<ST> &elements, const TracersST<ST> &tracers,
              const ReferenceElement &ref_FE, const HybridVCoord &hvcoord,
              const SphereOperatorsST<ST> &sphere_ops);
+  void setup(const ElementsST<ST> &elements,
+             const ReferenceElement &ref_FE, const HybridVCoord &hvcoord,
+             const SphereOperatorsST<ST> &sphere_ops)
+  {
+    setup(elements,{},ref_FE,hvcoord,sphere_ops);
+  }
 
   int requested_buffer_size () const;
   void init_buffers(const FunctorsBuffersManager& fbm);

--- a/components/homme/src/share/cxx/CaarFunctor.hpp
+++ b/components/homme/src/share/cxx/CaarFunctor.hpp
@@ -7,13 +7,14 @@
 #ifndef HOMMEXX_CAAR_FUNCTOR_HPP
 #define HOMMEXX_CAAR_FUNCTOR_HPP
 
-#include "CaarFunctorImpl.hpp"
 #include "Elements.hpp"
 #include "Tracers.hpp"
 #include "SphereOperators.hpp"
 #include "Types.hpp"
 #include "RKStageData.hpp"
+
 #include <memory>
+#include <any>
 
 namespace Homme {
 
@@ -51,8 +52,9 @@ public:
 
   void run(const RKStageData& data);
 
+  std::any& impl () { return m_caar_impl; }
 private:
-  std::unique_ptr<CaarFunctorImplST<ST>> m_caar_impl;
+  std::any m_caar_impl;
   bool is_setup;
 };
 

--- a/components/homme/src/share/cxx/CaarFunctor_def.hpp
+++ b/components/homme/src/share/cxx/CaarFunctor_def.hpp
@@ -27,17 +27,13 @@ namespace Homme {
 template<typename ST>
 CaarFunctorST<ST>::
 CaarFunctorST()
-  : is_setup(true)
+  : is_setup(false)
 {
-  auto& elements   = Context::singleton().get<ElementsST<ST>>();
-  auto& tracers    = Context::singleton().get<TracersST<ST>>();
-  auto& ref_FE     = Context::singleton().get<ReferenceElement>();
-  auto& hvcoord    = Context::singleton().get<HybridVCoord>();
-  auto& sphere_ops = Context::singleton().get<SphereOperatorsST<ST>>();
-  auto& params     = Context::singleton().get<SimulationParams>();
+  auto& geo     = Context::singleton().get<ElementsGeometry>();
+  auto& params  = Context::singleton().get<SimulationParams>();
 
   // Build functor impl
-  m_caar_impl = std::make_any<CaarFunctorImplST<ST>>(elements,tracers,ref_FE,hvcoord,sphere_ops,params);
+  m_caar_impl = std::make_any<CaarFunctorImplST<ST>>(geo.num_elems(),params);
 }
 
 template<typename ST>

--- a/components/homme/src/share/cxx/CaarFunctor_def.hpp
+++ b/components/homme/src/share/cxx/CaarFunctor_def.hpp
@@ -37,7 +37,7 @@ CaarFunctorST()
   auto& params     = Context::singleton().get<SimulationParams>();
 
   // Build functor impl
-  m_caar_impl.reset(new CaarFunctorImplST<ST>(elements,tracers,ref_FE,hvcoord,sphere_ops,params));
+  m_caar_impl = std::make_any<CaarFunctorImplST<ST>>(elements,tracers,ref_FE,hvcoord,sphere_ops,params);
 }
 
 template<typename ST>
@@ -50,7 +50,7 @@ CaarFunctorST(const ElementsST<ST> &elements, const TracersST<ST> &tracers,
   : is_setup(true)
 {
   // Build functor impl
-  m_caar_impl.reset(new CaarFunctorImplST<ST>(elements, tracers, ref_FE, hvcoord, sphere_ops, params));
+  m_caar_impl = std::make_any<CaarFunctorImplST<ST>>(elements, tracers, ref_FE, hvcoord, sphere_ops, params);
 }
 
 // This constructor is useful for using buffer functionality without
@@ -63,7 +63,7 @@ CaarFunctorST(const int num_elems, const SimulationParams& params)
   : is_setup(false)
 {
   // Build functor impl
-  m_caar_impl.reset(new CaarFunctorImplST<ST>(num_elems, params));
+  m_caar_impl = std::make_any<CaarFunctorImplST<ST>>(num_elems,params);
 }
 
 template<typename ST>
@@ -72,61 +72,50 @@ setup(const ElementsST<ST> &elements, const TracersST<ST> &tracers,
       const ReferenceElement &ref_FE, const HybridVCoord &hvcoord,
       const SphereOperatorsST<ST> &sphere_ops)
 {
-  assert (m_caar_impl);
-
   // Sanity check
   assert (!is_setup);
 
-  m_caar_impl->setup(elements, tracers, ref_FE, hvcoord, sphere_ops);
+  auto impl = std::any_cast<CaarFunctorImplST<ST>>(&m_caar_impl);
+  impl->setup(elements, tracers, ref_FE, hvcoord, sphere_ops);
   is_setup = true;
 }
 
 template<typename ST>
 int CaarFunctorST<ST>::requested_buffer_size () const {
-  assert (m_caar_impl);
-  return m_caar_impl->requested_buffer_size();
+  assert (is_setup);
+  auto impl = std::any_cast<CaarFunctorImplST<ST>>(&m_caar_impl);
+  return impl->requested_buffer_size();
 }
 
 template<typename ST>
 void CaarFunctorST<ST>::init_buffers(const FunctorsBuffersManager& fbm) {
-  assert (m_caar_impl);
-  m_caar_impl->init_buffers(fbm);
+  assert (is_setup);
+  auto impl = std::any_cast<CaarFunctorImplST<ST>>(&m_caar_impl);
+  impl->init_buffers(fbm);
 }
 
 template<typename ST>
 void CaarFunctorST<ST>::init_boundary_exchanges (const std::shared_ptr<MpiBuffersManager>& bm_exchange) {
-  assert (m_caar_impl);
-
   // The Functor needs to be fully setup to use this function
   assert (is_setup);
-
-  m_caar_impl->init_boundary_exchanges(bm_exchange);
+  auto impl = std::any_cast<CaarFunctorImplST<ST>>(&m_caar_impl);
+  impl->init_boundary_exchanges(bm_exchange);
 }
 
 template<typename ST>
 void CaarFunctorST<ST>::set_rk_stage_data (const RKStageData& data)
 {
-  // Sanity check (should NEVER happen)
-  assert (m_caar_impl);
-
-  // The Functor needs to be fully setup
   assert (is_setup);
-
-  // Forward inputs to impl
-  m_caar_impl->set_rk_stage_data(data);
+  auto impl = std::any_cast<CaarFunctorImplST<ST>>(&m_caar_impl);
+  impl->set_rk_stage_data(data);
 }
 
 template<typename ST>
 void CaarFunctorST<ST>::run (const RKStageData& data)
 {
-  // Sanity check (should NEVER happen)
-  assert (m_caar_impl);
-
-  // The Functor needs to be fully setup
   assert (is_setup);
-
-  // Run functor
-  m_caar_impl->run(data);
+  auto impl = std::any_cast<CaarFunctorImplST<ST>>(&m_caar_impl);
+  impl->run(data);
 }
 
 } // Namespace Homme

--- a/components/homme/src/theta-l_kokkos/CMakeLists.txt
+++ b/components/homme/src/theta-l_kokkos/CMakeLists.txt
@@ -182,6 +182,12 @@ MACRO(THETAL_KOKKOS_SETUP)
     ${SRC_SHARE_DIR}/cxx/utilities/InternalDiagnostics.cpp
   )
 
+  if (HOMMEXX_ENABLE_FAD_TYPES)
+    list(APPEND THETAL_DEPS_CXX
+      ${TARGET_DIR}/cxx/prim_advance_adj.cpp
+    )
+  endif()
+
   IF (HOMME_USE_ARKODE)
     SET(THETAL_DEPS_F90
       ${THETAL_DEPS_F90}

--- a/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
@@ -94,6 +94,7 @@ struct CaarFunctorImplST {
   const bool          m_theta_hydrostatic_mode;
   const AdvectionForm m_theta_advection_form;
   const bool          m_pgrad_correction;
+        bool          m_run_limiter = true;
 
   HybridVCoord                m_hvcoord;
   ElementsStateST<ST>         m_state;
@@ -385,7 +386,8 @@ struct CaarFunctorImplST {
       GPTLstop("caar compute");
     }
 
-    limiter.run(data.np1);
+    if (m_run_limiter)
+      limiter.run(data.np1);
   }
 
 #ifdef HOMMEXX_ENABLE_FAD_TYPES

--- a/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
@@ -125,7 +125,7 @@ struct CaarFunctorImplST {
 
   Kokkos::Array<std::shared_ptr<BoundaryExchangeST<ST>>, NUM_TIME_LEVELS> m_bes;
 
-  CaarFunctorImplST(const ElementsST<ST> &elements, const TracersST<ST>&/* tracers */,
+  CaarFunctorImplST(const ElementsST<ST> &elements,
                     const ReferenceElement &ref_FE, const HybridVCoord &hvcoord,
                     const SphereOperatorsST<ST> &sphere_ops, const SimulationParams& params)
       : m_num_elems(elements.num_elems())
@@ -149,6 +149,12 @@ struct CaarFunctorImplST {
     // Make sure the buffers in sph op are large enough for this functor's needs
     m_sphere_ops.allocate_buffers(m_tu);
   }
+
+  CaarFunctorImplST(const ElementsST<ST> &elements, const TracersST<ST>&/* tracers */,
+                    const ReferenceElement &ref_FE, const HybridVCoord &hvcoord,
+                    const SphereOperatorsST<ST> &sphere_ops, const SimulationParams& params)
+      : CaarFunctorImplST(elements,ref_FE,hvcoord,sphere_ops,params)
+  {}
 
   CaarFunctorImplST(const int num_elems, const SimulationParams& params)
       : m_num_elems(num_elems)

--- a/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/CaarFunctorImpl.hpp
@@ -1218,6 +1218,61 @@ struct CaarFunctorImplST {
     Kokkos::parallel_for(p4_int,jtv_int);
   }
 
+  // The jacobian transpose of the surf boundary condition (the TagPostExchange in the fwd pass)
+  template<typename MyST = ST>
+  std::enable_if_t<not std::is_same_v<MyST,DxFadTypeCaar>>
+  run_JtV_surf_bc (const RKStageData& data, const StateSnapshot& x, StateSnapshot& y) = delete;
+
+  template<typename MyST = ST>
+  std::enable_if_t<std::is_same_v<MyST,DxFadTypeCaar>>
+  run_JtV_surf_bc (const RKStageData& data, const StateSnapshot& x, StateSnapshot& y)
+  {
+    using namespace PhysicalConstants;
+    using md_range_t = Kokkos::MDRangePolicy<ExecSpace,Kokkos::Rank<3>>;
+    auto policy = md_range_t({0,0,0},{m_num_elems,NP,NP});
+
+    auto& gradphis = m_geometry.m_gradphis;
+
+    // Start copying all the adjoint states
+    y.deep_copy(x);
+
+    auto v_in = ekat::scalarize(x.v);
+    auto w_in = ekat::scalarize(x.w_i);
+    auto v_out = ekat::scalarize(y.v);
+    auto w_out = ekat::scalarize(y.w_i);
+    auto phi_out = ekat::scalarize(y.phinh_i);
+
+    auto jtv = KOKKOS_LAMBDA (int ie, int ip, int jp) {
+      // Since we set phinh_i=phis at surface, lambda_phi==0 at surface
+      // Note: x_phi should have been 0 at entry, but just in case
+      phi_out(ie,ip,jp,NUM_INTERFACE_LEV-1) = 0;
+
+      // Process the adjoint of u,v,w bc
+      auto phis_x = gradphis(ie,0,ip,jp);
+      auto phis_y = gradphis(ie,1,ip,jp);
+
+      auto A = phis_x / g;
+      auto B = phis_y / g;
+      auto D = data.dt*(g + (phis_x*phis_x+phis_y*phis_y)/(2*g));
+      auto S = data.scale1*data.dt;
+
+      auto& x_u = v_in(ie,0,ip,jp,NUM_PHYSICAL_LEV-1);
+      auto& x_v = v_in(ie,1,ip,jp,NUM_PHYSICAL_LEV-1);
+      auto& x_w = w_in(ie,  ip,jp,NUM_INTERFACE_LEV-1);
+      auto& y_u = v_out(ie,0,ip,jp,NUM_PHYSICAL_LEV-1);
+      auto& y_v = v_out(ie,1,ip,jp,NUM_PHYSICAL_LEV-1);
+      auto& y_w = w_out(ie,  ip,jp,NUM_INTERFACE_LEV-1);
+
+      auto M = S/D * (-phis_x/2*x_u -phis_y/2*x_v + g*x_w);
+
+      y_u += A * M;
+      y_v += B * M;
+      y_w += -1* M;
+    };
+
+    Kokkos::parallel_for(policy,jtv);
+  }
+
   // A version of run_JVt that computes the full element Jacobian instead of using column compression to help debugging
   // Note, to run this you need to set DxFadTypeCaar correctly based on the number of levels.  The formula is:
   //      NP*NP*(NUM_PHYSICAL_LEV*4 + NUM_INTERFACE_LEV*2)

--- a/components/homme/src/theta-l_kokkos/cxx/DirkFunctor.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/DirkFunctor.hpp
@@ -34,6 +34,7 @@ public:
   void run(int nm1, Real alphadt_nm1, int n0, Real alphadt_n0, int np1, Real dt2,
            const ElementsST<ST>& elements, const HybridVCoord& hvcoord);
 
+  std::any& impl () { return m_dirk_impl; }
 private:
   std::any m_dirk_impl;
 };

--- a/components/homme/src/theta-l_kokkos/cxx/prim_advance_adj.cpp
+++ b/components/homme/src/theta-l_kokkos/cxx/prim_advance_adj.cpp
@@ -1,0 +1,42 @@
+#include "prim_advance_adj.hpp"
+
+#include "mpi/MpiBuffersManager.hpp"
+#include "SimulationParams.hpp"
+#include "Context.hpp"
+
+namespace Homme
+{
+
+std::shared_ptr<BoundaryExchangeST<Real>> create_adj_bex (StateSnapshot& adj_state)
+{
+  auto& c = Context::singleton();
+  const auto& params = c.get<SimulationParams>();
+  auto& bmm = c.get<MpiBuffersManagerMap>();
+
+  auto be = std::make_shared<BoundaryExchangeST<Real>>();
+  be->m_label = std::string("AdjState");
+  be->set_buffers_manager(bmm[MPI_EXCHANGE]);
+  be->m_diagnostics_level = params.internal_diagnostics_level;
+  if (params.theta_hydrostatic_mode) {
+    be->set_num_fields(0,0,4);
+  } else {
+    be->set_num_fields(0,0,4,2);
+  }
+
+  be->register_field(adj_state.v,2,0);
+  be->register_field(adj_state.vtheta_dp);
+  be->register_field(adj_state.dp3d);
+  if (!params.theta_hydrostatic_mode) {
+    // Note: phinh_i at the surface (last level) is constant, so it doesn't *need* bex.
+    //       If bex(constant)=constant, we might just do it. This would not eliminate
+    //       the need for halo-exchange of interface-based quantities though, since
+    //       we would still need to exchange w_i.
+    be->register_field(adj_state.w_i);
+    be->register_field(adj_state.phinh_i);
+  }
+  be->registration_completed();
+
+  return be;
+}
+
+} // namespace Homme

--- a/components/homme/src/theta-l_kokkos/cxx/prim_advance_adj.hpp
+++ b/components/homme/src/theta-l_kokkos/cxx/prim_advance_adj.hpp
@@ -1,0 +1,16 @@
+#ifndef HOMMEXX_PRIM_ADVANCE_ADJ_HPP
+#define HOMMEXX_PRIM_ADVANCE_ADJ_HPP
+
+#include "mpi/BoundaryExchange.hpp"
+#include "StateSnapshot.hpp"
+#include "Types.hpp"
+
+#include <memory>
+
+namespace Homme {
+
+std::shared_ptr<BoundaryExchangeST<Real>> create_adj_bex (StateSnapshot& adj_state);
+
+} // namespace Homme
+
+#endif // HOMMEXX_PRIM_ADVANCE_ADJ_HPP

--- a/components/homme/test_execs/thetal_kokkos_ut/caar_sacado_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/caar_sacado_ut.cpp
@@ -936,6 +936,8 @@ TEST_CASE("caar_adjoint") {
 
         CaarFunctorImplST<DpFadType> caar_dp(elems_dp, ref_FE, hvcoord, sphop_dp, params);
         CaarFunctorImplST<DxFadType> caar_dx(elems_dx, ref_FE, hvcoord, sphop_dx, params);
+        caar_dx.m_run_limiter = false;
+        caar_dp.m_run_limiter = false;
 
         FunctorsBuffersManager fbm;
         fbm.request_size(caar_dp.requested_buffer_size());

--- a/components/homme/test_execs/thetal_kokkos_ut/caar_sacado_ut.cpp
+++ b/components/homme/test_execs/thetal_kokkos_ut/caar_sacado_ut.cpp
@@ -6,6 +6,7 @@
 #include "SimulationParams.hpp"
 #include "Tracers.hpp"
 #include "PhysicalConstants.hpp"
+#include "prim_advance_adj.hpp"
 
 #include "utilities/TestUtils.hpp"
 
@@ -738,6 +739,269 @@ TEST_CASE("caar_jtv_check") {
           KOKKOS_LAMBDA(int ie, int ip, int jp, int k, Real2& acc) {
             acc.v[0] += sxa_w(ie, ip, jp, k) * syb_w(ie, ip, jp, k);
             acc.v[1] += sya_w(ie, ip, jp, k) * sxb_w(ie, ip, jp, k);
+          }, w_dot);
+
+        gdot += V_dot;
+        gdot += vth_dot;
+        gdot += dp_dot;
+        gdot += phi_dot;
+        gdot += w_dot;
+
+        CHECK_THAT(gdot.v[0], Catch::WithinRel(gdot.v[1], rtol) || Catch::WithinAbs(gdot.v[1], atol));
+
+        if (comm.am_i_root())
+          std::cout << std::setprecision(15)
+                    << "       <a, J*b> = " << gdot.v[0]
+                    << ",  <J^T*a, b> = " << gdot.v[1] << "\n";
+      }
+    }
+  }
+
+  cleanup_f90();
+  c.finalize_singleton();
+}
+
+TEST_CASE("caar_adjoint") {
+  using namespace PhysicalConstants;
+  using DxFadType = DxFadTypeCaar;
+
+  std::random_device rd;
+  using rngAlg = std::mt19937_64;
+  const unsigned int catchRngSeed = Catch::rngSeed();
+  const unsigned int seed = catchRngSeed==0 ? rd() : catchRngSeed;
+  std::cout << "seed: " << seed << (catchRngSeed==0 ? " (catch rng seed was 0)\n" : "\n");
+  rngAlg engine(seed);
+  using RPDF = std::uniform_real_distribution<Real>;
+
+  auto& c = Context::singleton();
+  c.create<ekat::Comm>(MPI_COMM_WORLD);
+
+  auto& params = c.create<SimulationParams>();
+
+  constexpr int ne = 2;
+  params.dp3d_thresh   = 0;
+  params.vtheta_thresh = 0;
+  params.params_set    = true;
+  params.rsplit        = 3;
+
+  auto& hvcoord = c.create<HybridVCoord>();
+  auto& ref_FE  = c.create<ReferenceElement>();
+  hvcoord.random_init(seed);
+
+  auto hyai = Kokkos::create_mirror_view(hvcoord.hybrid_ai);
+  auto hybi = Kokkos::create_mirror_view(hvcoord.hybrid_bi);
+  auto hyam = Kokkos::create_mirror_view(hvcoord.hybrid_am);
+  auto hybm = Kokkos::create_mirror_view(hvcoord.hybrid_bm);
+  Kokkos::deep_copy(hyai, hvcoord.hybrid_ai);
+  Kokkos::deep_copy(hybi, hvcoord.hybrid_bi);
+  Kokkos::deep_copy(hyam, hvcoord.hybrid_am);
+  Kokkos::deep_copy(hybm, hvcoord.hybrid_bm);
+
+  HostViewManaged<Real[NUM_PHYSICAL_LEV]> hyam_r(""), hybm_r("");
+  for (int i = 0; i < NUM_PHYSICAL_LEV; ++i) {
+    int ilev = i / VECTOR_SIZE;
+    int ivec = i % VECTOR_SIZE;
+    hyam_r(i) = ADValue(hyam(ilev)[ivec]);
+    hybm_r(i) = ADValue(hybm(ilev)[ivec]);
+  }
+
+  std::vector<Real> dvv(NP*NP), mp(NP*NP);
+  init_f90(ne, hyai.data(), hybi.data(), hyam_r.data(), hybm_r.data(),
+           dvv.data(), mp.data(), hvcoord.ps0);
+  ref_FE.init_mass(mp.data());
+  ref_FE.init_deriv(dvv.data());
+
+  const int  num_elems    = c.get<Connectivity>().get_num_local_elements();
+  const Real max_pressure = 1000.0 + hvcoord.ps0;
+
+  auto& geo = c.create<ElementsGeometry>();
+  geo.init(num_elems,false,true,rearth0,1/rearth0,true);
+  geo.randomize(seed);
+
+  auto& elems_dp = c.create<ElementsST<DpFadType>>();
+  auto& elems_dx = c.create<ElementsST<DxFadType>>();
+  elems_dp.init(num_elems, false, true, PhysicalConstants::rearth0);
+  elems_dx.init(num_elems, false, true, PhysicalConstants::rearth0);
+  elems_dx.m_geometry = elems_dp.m_geometry = geo;
+  Kokkos::deep_copy(elems_dp.m_derived.m_vn0,DpFadType(0));
+  Kokkos::deep_copy(elems_dp.m_derived.m_omega_p,DpFadType(0));
+  Kokkos::deep_copy(elems_dx.m_derived.m_vn0,DxFadType(0));
+  Kokkos::deep_copy(elems_dx.m_derived.m_omega_p,DxFadType(0));
+
+  auto& sphop_dp = c.create<SphereOperatorsST<DpFadType>>();
+  auto& sphop_dx = c.create<SphereOperatorsST<DxFadType>>();
+
+  auto& limiter_dp = c.create<LimiterFunctorST<DpFadType>>(elems_dp, hvcoord, params);
+  auto& limiter_dx = c.create<LimiterFunctorST<DxFadType>>(elems_dx, hvcoord, params);
+  limiter_dp.m_verbose = false;
+  limiter_dx.m_verbose = false;
+
+  sphop_dp.setup(geo, ref_FE);
+  sphop_dx.setup(geo, ref_FE);
+
+  auto& bmm  = c.create<MpiBuffersManagerMap>();
+  auto  bm   = bmm[MPI_EXCHANGE];
+  auto conn  = c.get_ptr<Connectivity>();
+  if (!bm->is_connectivity_set()) {
+    bm->set_connectivity(conn);
+  }
+
+  auto& comm    = c.get<ekat::Comm>();
+  const int nm1 = 0, n0 = 1, np1 = 2;
+
+  // StateSnapshot xa(num_elems), xb(num_elems), ya(num_elems), yb(num_elems);
+  StateSnapshot x_fwd (num_elems), y_fwd(num_elems);
+  StateSnapshot x_bwd (num_elems), y_bwd(num_elems), tmp_bwd(num_elems);
+
+  // Scalarized device views (share memory with the packed views above).
+  auto xfwd_v   = ekat::scalarize(x_fwd.v);
+  auto xfwd_vth = ekat::scalarize(x_fwd.vtheta_dp);
+  auto xfwd_dp  = ekat::scalarize(x_fwd.dp3d);
+  auto xfwd_phi = ekat::scalarize(x_fwd.phinh_i);
+  auto xfwd_w   = ekat::scalarize(x_fwd.w_i);
+
+  auto xbwd_v   = ekat::scalarize(x_bwd.v);
+  auto xbwd_vth = ekat::scalarize(x_bwd.vtheta_dp);
+  auto xbwd_dp  = ekat::scalarize(x_bwd.dp3d);
+  auto xbwd_phi = ekat::scalarize(x_bwd.phinh_i);
+  auto xbwd_w   = ekat::scalarize(x_bwd.w_i);
+
+  auto yfwd_v   = ekat::scalarize(y_fwd.v);
+  auto yfwd_vth = ekat::scalarize(y_fwd.vtheta_dp);
+  auto yfwd_dp  = ekat::scalarize(y_fwd.dp3d);
+  auto yfwd_phi = ekat::scalarize(y_fwd.phinh_i);
+  auto yfwd_w   = ekat::scalarize(y_fwd.w_i);
+
+  auto ybwd_v   = ekat::scalarize(y_bwd.v);
+  auto ybwd_vth = ekat::scalarize(y_bwd.vtheta_dp);
+  auto ybwd_dp  = ekat::scalarize(y_bwd.dp3d);
+  auto ybwd_phi = ekat::scalarize(y_bwd.phinh_i);
+  auto ybwd_w   = ekat::scalarize(y_bwd.w_i);
+
+  using p3_t = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<3>>;
+  using p4_t = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<4>>;
+  using p5_t = Kokkos::MDRangePolicy<ExecSpace, Kokkos::Rank<5>>;
+  const p4_t p4_mid({0,0,0,0}, {num_elems, NP, NP, NUM_PHYSICAL_LEV});
+  const p5_t p5_mid({0,0,0,0,0}, {num_elems, 2, NP, NP, NUM_PHYSICAL_LEV});
+  const p4_t p4_int({0,0,0,0}, {num_elems, NP, NP, NUM_INTERFACE_LEV});
+
+  const Real rtol = 1e-8;
+  const Real atol = 1e-8;
+
+  // Make rspheremp equal to 1/BE(spheremp) (needed to ensure adjoint works)
+  Kokkos::deep_copy(geo.m_rspheremp,geo.m_spheremp);
+  BoundaryExchangeST<Real> be_mass(conn,bm);
+  be_mass.set_num_fields(0,1,0);
+  be_mass.register_field(geo.m_rspheremp);
+  be_mass.registration_completed();
+  be_mass.exchange();
+  auto do_inverse = KOKKOS_LAMBDA (int ie, int ip, int jp) {
+    geo.m_rspheremp(ie,ip,jp) = 1 / geo.m_rspheremp(ie,ip,jp);
+  };
+  Kokkos::parallel_for(p3_t({0,0,0},{num_elems,NP,NP}),do_inverse);
+
+  // NOTE: cannot yet use hydrostatic=true (requires a scan sum not supported here)
+  for (const bool hydrostatic : {false}) {
+    params.theta_hydrostatic_mode       = hydrostatic;
+    limiter_dp.m_theta_hydrostatic_mode = hydrostatic;
+    limiter_dx.m_theta_hydrostatic_mode = hydrostatic;
+    if (comm.am_i_root())
+      std::cout << " -> " << (hydrostatic ? "Hydrostatic\n" : "Non-Hydrostatic\n");
+
+    for (const AdvectionForm adv_form : {AdvectionForm::Conservative,
+                                         AdvectionForm::NonConservative}) {
+      params.theta_adv_form = adv_form;
+      if (comm.am_i_root())
+        std::cout << "  -> " << (adv_form==AdvectionForm::Conservative
+                                 ? "Conservative" : "Non-Conservative")
+                  << " theta advection\n";
+
+      for (const int pgrad : {1, 0}) {
+        params.pgrad_correction = (pgrad != 0);
+        if (comm.am_i_root())
+          std::cout << "    -> pgrad_correction = " << pgrad << "\n";
+
+        Real dt        = RPDF(1.0, 10.0)(engine);
+        Real eta_ave_w = RPDF(0.1,  1.0)(engine);
+        Real scale1    = RPDF(1.0,  2.0)(engine);
+        Real scale2    = RPDF(1.0,  2.0)(engine);
+        Real scale3    = RPDF(1.0,  2.0)(engine);
+        comm.broadcast(&dt,        1, 0);
+        comm.broadcast(&scale1,    1, 0);
+        comm.broadcast(&scale2,    1, 0);
+        comm.broadcast(&scale3,    1, 0);
+        comm.broadcast(&eta_ave_w, 1, 0);
+
+        RKStageData data(nm1, n0, np1, 0, dt, eta_ave_w, scale1, scale2, scale3);
+
+        CaarFunctorImplST<DpFadType> caar_dp(elems_dp, ref_FE, hvcoord, sphop_dp, params);
+        CaarFunctorImplST<DxFadType> caar_dx(elems_dx, ref_FE, hvcoord, sphop_dx, params);
+
+        FunctorsBuffersManager fbm;
+        fbm.request_size(caar_dp.requested_buffer_size());
+        fbm.request_size(caar_dx.requested_buffer_size());
+        fbm.request_size(limiter_dp.requested_buffer_size());
+        fbm.request_size(limiter_dx.requested_buffer_size());
+        fbm.allocate();
+        caar_dp.init_buffers(fbm);
+        caar_dx.init_buffers(fbm);
+        limiter_dp.init_buffers(fbm);
+        limiter_dx.init_buffers(fbm);
+        caar_dp.init_boundary_exchanges(bm);
+
+        auto adj_bex = create_adj_bex(tmp_bwd);
+
+        // Randomize data: fwd sens state and bwd adjoint var
+        elems_dp.m_state.randomize(seed, max_pressure, hvcoord.ps0,
+                                   hvcoord.hybrid_ai0, geo.m_phis);
+        elems_dx.m_state.import_values(elems_dp.m_state,nm1);
+        elems_dx.m_state.import_values(elems_dp.m_state,n0);
+
+        elems_dp.m_state.randomize_derivs(seed, n0);
+        elems_dp.m_state.take_deriv_snapshot(x_fwd,n0,0);
+        x_bwd.randomize(seed, max_pressure, hvcoord.ps0, hvcoord.hybrid_ai0, geo.m_phis);
+
+        // Run fwd sens CAAR
+        caar_dp.run(data);
+        elems_dp.m_state.take_deriv_snapshot(y_fwd,np1,0);
+
+        // Run adj CAAR
+        caar_dx.run_JtV_surf_bc(data,x_bwd,tmp_bwd);
+        adj_bex->exchange(geo.m_rspheremp);
+        caar_dx.init_J(data);
+        caar_dx.run_pre_exchange(data);
+        caar_dx.run_JtV(data,tmp_bwd,y_bwd);
+
+        // Check that (x_fwd,y_bwd) = (y_fwd,x_bwd)
+        // Note: we must sum over all state vars, since J and J^T scramble them differently
+        //       The contributions of each vars are kept just for debugging weird vals (like nans)
+        Real2 V_dot, vth_dot, dp_dot, phi_dot, w_dot;
+        Real2 gdot;
+
+        Kokkos::parallel_reduce(p5_mid,
+          KOKKOS_LAMBDA(int ie, int icmp, int ip, int jp, int k, Real2& acc) {
+            acc.v[0] += xfwd_v(ie, icmp, ip, jp, k) * ybwd_v(ie, icmp, ip, jp, k);
+            acc.v[1] += yfwd_v(ie, icmp,  ip, jp, k) * xbwd_v(ie,icmp,  ip, jp, k);
+          }, V_dot);
+        Kokkos::parallel_reduce(p4_mid,
+          KOKKOS_LAMBDA(int ie, int ip, int jp, int k, Real2& acc) {
+            acc.v[0] += xfwd_vth(ie, ip, jp, k) * ybwd_vth(ie, ip, jp, k);
+            acc.v[1] += yfwd_vth(ie, ip, jp, k) * xbwd_vth(ie, ip, jp, k);
+          }, vth_dot);
+        Kokkos::parallel_reduce(p4_mid,
+          KOKKOS_LAMBDA(int ie, int ip, int jp, int k, Real2& acc) {
+            acc.v[0] += xfwd_dp(ie, ip, jp, k) * ybwd_dp(ie, ip, jp, k);
+            acc.v[1] += yfwd_dp(ie, ip, jp, k) * xbwd_dp(ie, ip, jp, k);
+          }, dp_dot);
+        Kokkos::parallel_reduce(p4_int,
+          KOKKOS_LAMBDA(int ie, int ip, int jp, int k, Real2& acc) {
+            acc.v[0] += xfwd_phi(ie, ip, jp, k) * ybwd_phi(ie, ip, jp, k);
+            acc.v[1] += yfwd_phi(ie, ip, jp, k) * xbwd_phi(ie, ip, jp, k);
+          }, phi_dot);
+        Kokkos::parallel_reduce(p4_int,
+          KOKKOS_LAMBDA(int ie, int ip, int jp, int k, Real2& acc) {
+            acc.v[0] += xfwd_w(ie, ip, jp, k) * ybwd_w(ie, ip, jp, k);
+            acc.v[1] += yfwd_w(ie, ip, jp, k) * xbwd_w(ie, ip, jp, k);
           }, w_dot);
 
         gdot += V_dot;


### PR DESCRIPTION
Test the adjoint of the whole CAAR functor, inlcuding halo exchange and post-exchange kernel.

---

The current `run_JtV` function only computes the adjoint of local calculations. In a typical run, we also need the adjoint of the halo exchange as well as the post-exchange kernel (which simply sets some boundary conditions).

The tests are currently not passing. I'm creating the PR so I can ask for help from copilot, pointing it to the output of the failing CI tests.

This PR is built on top of #40, so it should be merged after that.